### PR TITLE
Fix #83: Very long words can run out of container

### DIFF
--- a/source/_static/css/opnsense.css
+++ b/source/_static/css/opnsense.css
@@ -3671,6 +3671,9 @@ code, .rst-content tt, .rst-content code {
 @media print {
   .wy-breadcrumbs li.wy-breadcrumbs-aside {
     display: none; } }
+body {
+  overflow-wrap: break-word; }
+
 .wy-affix {
   position: fixed;
   top: 1.618em; }

--- a/themes/opnsense/sass/_theme_layout.sass
+++ b/themes/opnsense/sass/_theme_layout.sass
@@ -1,3 +1,6 @@
+body
+  overflow-wrap: break-word
+
 .wy-affix
   position: fixed
   top: $gutter


### PR DESCRIPTION
overflow-wrap will attempt not to break words if it can help it. It will only break it up when the word is too long to fit onto its own line.