### PR TITLE
Fix text wrapping in tables

### DIFF
--- a/source/_static/css/theme-overrides.css
+++ b/source/_static/css/theme-overrides.css
@@ -1,0 +1,13 @@
+/* override table width restrictions */
+@media screen and (min-width: 767px) {
+
+    .wy-table-responsive table td {
+        /* !important prevents the common CSS stylesheets from overriding
+           this as on RTD they are loaded after this stylesheet */
+        white-space: normal !important;
+    }
+
+    .wy-table-responsive {
+        overflow: visible !important;
+    }
+}

--- a/source/conf.py
+++ b/source/conf.py
@@ -164,6 +164,12 @@ html_favicon = '_static/favicon.ico'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+html_context = {
+    'css_files': [
+        '_static/css/theme-overrides.css',  # override wide tables in RTD theme
+    ]
+}
+
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.


### PR DESCRIPTION
This makes the text in tables wrap around if it gets too wide, rather than widening the table and adding a horizontal scrollbar.
Fix is taken from here: https://rackerlabs.github.io/docs-rackspace/tools/rtd-tables.html

<img width="1701" alt="voor" src="https://user-images.githubusercontent.com/42928941/52407471-afa68200-2ad0-11e9-9c92-328a73e9dbe9.png">
<img width="1701" alt="na" src="https://user-images.githubusercontent.com/42928941/52407473-b0d7af00-2ad0-11e9-8f01-d3633026f9c0.png">
