### PR TITLE
Clarify gateways log purpose

### DIFF
--- a/source/manual/logging.rst
+++ b/source/manual/logging.rst
@@ -15,7 +15,7 @@ System
  **Backend / config daemon**   **System->Log Files->Backend**   *Here you can find logs for config generation of API usage*
  **Web GUI**                   **System->Log Files->Web GUI**   *Lighttpd, the webserver of OPNsense itself, logs here*
  **Firmware**                  **System->Firmware->Log File**   *Updates from the packaging system go here*
- **Gateways**                  **System->Gateways->Log File**   *Apinger/Dpinger gateway tracking related log messages are shere*
+ **Gateways**                  **System->Gateways->Log File**   *Lists Dpinger gateway tracking related log messages*
  **Routing**                   **System->Routes->Log File**     *Routing changes or interface events*
 ============================= ================================ ============================================================= 
 

--- a/source/manual/logging.rst
+++ b/source/manual/logging.rst
@@ -25,7 +25,7 @@ System
    /var/log/configd.log (clog)
    /var/log/lighttpd.log (clog)
    /var/log/pkg.log (clog)
-   /var/log/gateways.log (clog) Note: By default gateway monitoring is disabled, the log is empty
+   /var/log/gateways.log (clog) Note: By default gateway monitoring is disabled, so the log will be empty.
    /var/log/routing.log (clog)
 
 ----------

--- a/source/manual/logging.rst
+++ b/source/manual/logging.rst
@@ -15,7 +15,7 @@ System
  **Backend / config daemon**   **System->Log Files->Backend**   *Here you can find logs for config generation of API usage*
  **Web GUI**                   **System->Log Files->Web GUI**   *Lighttpd, the webserver of OPNsense itself, logs here*
  **Firmware**                  **System->Firmware->Log File**   *Updates from the packaging system go here*
- **Gateways**                  **System->Gateways->Log File**   *All about gateway tracking*
+ **Gateways**                  **System->Gateways->Log File**   *Apinger/Dpinger gateway tracking related log messages are shere*
  **Routing**                   **System->Routes->Log File**     *Routing changes or interface events*
 ============================= ================================ ============================================================= 
 
@@ -25,7 +25,7 @@ System
    /var/log/configd.log (clog)
    /var/log/lighttpd.log (clog)
    /var/log/pkg.log (clog)
-   /var/log/gateways.log (clog)
+   /var/log/gateways.log (clog) Note: By default gateway monitoring is disabled, the log is empty
    /var/log/routing.log (clog)
 
 ----------


### PR DESCRIPTION
Added some extra words about gateways log, what it is used for in a more clear language, and note that by default it does not contain any data, as gateway monitoring is disabled.