### PR TITLE
Correct opnsense-update help command

### DIFF
--- a/source/manual/install.rst
+++ b/source/manual/install.rst
@@ -458,7 +458,7 @@ OPNsense features a command line
 interface (CLI) tool "opnsense-update". Via menu option **8) Shell**, the user can
 get to the shell and use opnsense-update.
 
-For help type *opnsense-update -help* and [Enter]
+For help, type *man opnsense-update* and press [Enter].
 
 .. rubric:: Upgrade from console
    :name: upgrade-from-console


### PR DESCRIPTION
`opnsense-update -help`, `opnsense-update --help` or `opnsense-update -h` do not work. As running it already says, the correct way is `man opnsense-update`.