### PR TITLE
Fixed doc regarding tunnel adress for local instance

### DIFF
--- a/source/manual/how-tos/wireguard-client-mullvad.rst
+++ b/source/manual/how-tos/wireguard-client-mullvad.rst
@@ -29,7 +29,7 @@ Now change to your OPNsense CLI via SSH or Console and execute the curl string b
 
     curl -sSL https://api.mullvad.net/wg/ -d account=123 --data-urlencode pubkey=PUBKEY
     
-What you receive is the tunnel address for your local instance. Edit your instance again and remove
+What you receive is what WireGuard calls **Allowed IP** for your local instance. Edit your instance again and remove
 the value of **Tunnel Address** you used when setting it up and change it to the one you got.
 
 On **Endpoint** tab create a new Endpoint, give it a **Name**, set 0.0.0.0/0 in **Allowed IPs** and set

--- a/source/manual/how-tos/wireguard-client-mullvad.rst
+++ b/source/manual/how-tos/wireguard-client-mullvad.rst
@@ -29,8 +29,8 @@ Now change to your OPNsense CLI via SSH or Console and execute the curl string b
 
     curl -sSL https://api.mullvad.net/wg/ -d account=123 --data-urlencode pubkey=PUBKEY
     
-What you receive is what WireGuard calls **Allowed IP** for your local instance, so edit your instance again, remove
-the value of **Allowed IPs** you used when setting up and change it to the one you got.
+What you receive is the tunnel address for your local instance. Edit your instance again and remove
+the value of **Tunnel Address** you used when setting it up and change it to the one you got.
 
 On **Endpoint** tab create a new Endpoint, give it a **Name**, set 0.0.0.0/0 in **Allowed IPs** and set
 the **DNS** to 193.138.218.74. This is the one MulladVPN provides for privacy.


### PR DESCRIPTION
In step 1 the documentation says

> What you receive is what WireGuard calls Allowed IP for your local instance, so edit your instance again, remove the value of Allowed IPs you used when setting up and change it to the one you got.


However, there is no "Allowed IPs" field for the local instance. I believe what should be edited is the "Tunnel Address" field of the local instance.