### PR TITLE
add Quectel EG25-G modem to list of tested devices

### DIFF
--- a/source/manual/interfaces.rst
+++ b/source/manual/interfaces.rst
@@ -138,6 +138,7 @@ Tested devices by the OPNsense team include:
 
 * **Huawei ME909u-521** (device cuaUx.0)
 * **Huawei E220** (device cuaUx.0)
+* **Quectel EG25-G** (device cuaUx.2)
 * **Sierra Wireless MC7304** (device cuaUx.2) [as of OPNsense 16.7]
 
 .. Note::


### PR DESCRIPTION
The Quectel EG25-G modem has been successfully tested with OPNsense 19.7:
https://www.thomas-krenn.com/en/wiki/OPNsense_LTE_connection#Configure_Modem