### PR TITLE
Give a heads up about whitespace

### DIFF
--- a/source/manual/how-tos/cloud_backup.rst
+++ b/source/manual/how-tos/cloud_backup.rst
@@ -76,7 +76,9 @@ First we need to have a project in the google developer console:
       -  Download the key and save it (for your own use)
       -  Click "Generate new P12 key" and download the key (for your own
          use, you need this one later)
-      -  Copy Email Address, you need it later.
+      -  Copy Email Address, you need it later (be careful to avoid copying
+         leading or trailing whitespae as this will cause spurious failure in
+         OPNsense when pasted in verbatim).
 
 .. rubric:: Create a Google Drive folder
    :name: create-a-google-drive-folder


### PR DESCRIPTION
Leading or trailing whitespace is not trimmed from text fields on save in the opensense webui when pasting in the email address.
This can lead to confusion as to why the process fails (should the behaviour in the webui should be changed, instead of documenting a shortcoming instead?)