### PR TITLE
Update NAT port forward settings list

### DIFF
--- a/source/manual/how-tos/proxytransparent.rst
+++ b/source/manual/how-tos/proxytransparent.rst
@@ -58,9 +58,6 @@ left of the **Enable Transparent HTTP proxy** option and click on **add a new fi
 
 The defaults should be alright, just press **Save** and **Apply Changes**.
 
-.. NOTE::
-  If you use **TCP/IP Version**: IPv4+IPv6, the **Redirect target IP** should be either 127.0.0.1/32 or ::1/128. Both are loopback addresses for localhost and either one can be used. You can only enter one in the Target IP field. 
-
 Step 4 - CA for Transparent SSL
 --------------------------------------
 Before we can setup transparent SSL/HTTPS proxy we need to create a Certificate
@@ -144,9 +141,6 @@ left of the **Enable SSL mode** option and click on **add a new firewall rule**.
 ============================ =================================
 
 The defaults should be alright, just press **Save** and **Apply Changes**.
-
-.. NOTE::
-  If you use **TCP/IP Version**: IPv4+IPv6, the **Redirect target IP** should be either 127.0.0.1/32 or ::1/128. Both are loopback addresses for localhost and either one can be used. You can only enter one in the Target IP field. 
   
 Step 8 - Configure OS/Browser
 -----------------------------

--- a/source/manual/how-tos/proxytransparent.rst
+++ b/source/manual/how-tos/proxytransparent.rst
@@ -43,6 +43,7 @@ left of the **Enable Transparent HTTP proxy** option and click on **add a new fi
 
 ============================ =================================
  **Interface**                LAN
+ **TCP/IP VERSION**           IPv4
  **Protocol**                 TCP
  **Source**                   LAN net
  **Source port range**        any - any
@@ -57,6 +58,8 @@ left of the **Enable Transparent HTTP proxy** option and click on **add a new fi
 
 The defaults should be alright, just press **Save** and **Apply Changes**.
 
+.. NOTE::
+  If you use **TCP/IP Version**: IPv4+IPv6, the **Redirect target IP** should be either 127.0.0.1/32 or ::1/128. Both are loopback addresses for localhost and either one can be used. You can only enter one in the Target IP field. 
 
 Step 4 - CA for Transparent SSL
 --------------------------------------
@@ -127,6 +130,7 @@ left of the **Enable SSL mode** option and click on **add a new firewall rule**.
 
 ============================ =================================
  **Interface**                LAN
+ **TCP/IP VERSION**           IPv4
  **Protocol**                 TCP
  **Source**                   LAN net
  **Source port range**        any - any
@@ -141,6 +145,9 @@ left of the **Enable SSL mode** option and click on **add a new firewall rule**.
 
 The defaults should be alright, just press **Save** and **Apply Changes**.
 
+.. NOTE::
+  If you use **TCP/IP Version**: IPv4+IPv6, the **Redirect target IP** should be either 127.0.0.1/32 or ::1/128. Both are loopback addresses for localhost and either one can be used. You can only enter one in the Target IP field. 
+  
 Step 8 - Configure OS/Browser
 -----------------------------
 Since the CA is not trusted by your browser, you will get a message about this


### PR DESCRIPTION
If TCP/IP version is IPv4+IPv6, the redirect target IP has to include the CIDR when using the combined. This results in 127.0.0.1/32 or ::1/128. One or the other can be put in the Target IP field.