### PR TITLE
corrected download -> upload in 2nd rule of multi interface/guest net example

### DIFF
--- a/source/manual/how-tos/shaper.rst
+++ b/source/manual/how-tos/shaper.rst
@@ -641,7 +641,7 @@ Create a rule for the upload traffic
  **src-port**            any                *The source port to shape, leave on any*
  **destination**         any                *The destination IP to shape, leave on any*
  **dst-port**            any                *The destination port to shape, leave on any*
- **direction**           out                *Match incoming packages (download)*
+ **direction**           out                *Match outgoing packages (upload)*
  **target**             PipeUp-1Mbps        *Select the Download pipe*
  **description**        GuestNetUpload      *Enter a descriptive name*
 ====================== =================== =====================================================


### PR DESCRIPTION
If I understood the how-to correctly, the second rule of the "Multi Interface shaping for a GuestNet" example had a wrong description for the 'direction' field