### PR TITLE
fix image caption

### DIFF
--- a/source/manual/how-tos/shaper.rst
+++ b/source/manual/how-tos/shaper.rst
@@ -190,7 +190,7 @@ Upload that we want to share evenly between all users.
 
 .. nwdiag::
   :scale: 100%
-  :caption: Shaping hosted VOIP / SIP trunk sample
+  :caption: Shaping bandwidth evenly sample
 
     nwdiag {
 


### PR DESCRIPTION
image caption for "sharing bandwidth evenly" was referencing the example "reserve traffic for VoIP host/SIP trunk" before.

*Note:* the other captions are not too self explaining either -- not sure if that should be changed as well.