### PR TITLE
OpenConnect VPN firewall interface mention

### DIFF
--- a/source/manual/how-tos/openconnect.rst
+++ b/source/manual/how-tos/openconnect.rst
@@ -27,6 +27,9 @@ The setup of the client is very simple. Just tick **Enable** and fill out **VPN 
 **Username** and **Password**. Be sure that the FQDN matches the name in the certificate 
 or you will receive an error. Also wildcard certificates can produce errors.
 
+Once enabled, a new interface will be available for specifying firewall rules;
+:menuselection:`Firewall --> Rules --> OpenConnect` will appear.
+
 ------------------------------
 Step 3 - Troubleshoot problems
 ------------------------------


### PR DESCRIPTION
I noticed https://github.com/opnsense/docs/pull/35 doing something similar to what I intended (improving the documentation for future users like myself, with perhaps too much network-specific details), so I reduced my addition in trying to maintain the clear separation between the OpenConnect plugin and "basic networking". If there is  a page detailing the basics of setting up a VPN connection was ever created, it would be helpful to new users landing on this page. Alternatively, if linking to external guides is not frowned upon, I found the following helpful: https://www.routerperformance.net/using-openconnect-with-newly-released-opnsense-18-1-1/ .