### PR TITLE
Add correct menu location for Diagnostic --> Services

### DIFF
--- a/source/manual/how-tos/cachingproxy.rst
+++ b/source/manual/how-tos/cachingproxy.rst
@@ -41,7 +41,7 @@ Check the **Enable local cache** and click **Apply**.
 .. Important::
 
   As the cache is not created by default you will need to stop and start the service
-  under :menuselection:`Services --> Diagnostics`, this will ensure correct creation of the cache.
+  under :menuselection:`System --> Diagnostics --> Services`, this will ensure correct creation of the cache.
 
 Advanced
 --------


### PR DESCRIPTION
In OPNsense 20.1.7-amd64 the correct Menu Location for Diagnostics is: `System --> Diagnostics --> Services`

Affected file: `source/manual/how-tos/cachingproxy.rst`

Thank you