### PR TITLE
Update tor.rst

### DIFF
--- a/source/manual/how-tos/tor.rst
+++ b/source/manual/how-tos/tor.rst
@@ -221,7 +221,7 @@ Relays
 ------
 
 A Tor relay is a host which forwards traffic for other Tor nodes.
-A relay, which allows to pass traffic outside of the Tor network,
+A relay that allows traffic to pass outside of the Tor network
 is called an "Exit Node". If the relay is configured only for you
 (not for public access), it is called a bridge.
 Bridges are used to circumvent filtering of public entry nodes based


### PR DESCRIPTION
This small edit clarifies that a Tor exit node is a certain kind of relay. The implication in the current documentation is that all relays are exit nodes. (See: https://www.grammarly.com/blog/which-vs-that/.)