### PR TITLE
Add new LTE card to interfaces.rst

### DIFF
--- a/source/manual/interfaces.rst
+++ b/source/manual/interfaces.rst
@@ -150,6 +150,7 @@ To make thing easier some of these strings are part of a easy selectable profile
 
 Tested devices by the OPNsense team include:
 
+* **Huaweu M909S-120** (device cuaUx.0) (Requires separate SIM card holder/adapter) [Tested: OPNsense 21.1]
 * **Huawei ME909u-521** (device cuaUx.0)
 * **Huawei E220** (device cuaUx.0)
 * **Sierra Wireless MC7304** (device cuaUx.2) [as of OPNsense 16.7]


### PR DESCRIPTION
Adding M909S-120 to compatible list. Verified as working on my desktop with the fibre line hard disconnected (removed at the wall!), playing YouTube etc just fine. Requires an adaptor board for the SIM card -- these are readily available in the UK on eBay, Amazon etc. I got my parts there, total cost £75 so very cheap indeed. No special steps required otherwise, just install the unlocked SIM card, boot up OPNsense and the card shows up just fine! Simple plug & play.