### PR TITLE
clarify number of Public Services needed

### DIFF
--- a/source/manual/how-tos/haproxy.rst
+++ b/source/manual/how-tos/haproxy.rst
@@ -148,8 +148,8 @@ is a Public Service.
 A Public Service is a a group of bound ports which are used for incoming connections.
 From this Public Service we need to know which backend the request will routed to.
 For this, the previously configured action is needed.
-If you got multiple domains on one IP, you differentiate them with rules! 
-Don't create multiple Public Services.
+If you got multiple domains with the same port on one IP, you differentiate them with rules! 
+Don't create multiple Public Services. For example, if you only want to forward example.org:80 and example.com:80, just create one Public Service. If you want to forward example.org:80, example.org:443, example.com:80, and example.com:443, create only two Public Services, one for port 80 (example.org and example.com) and one for port 443 (example.org and example.com).
 
 To create a new Public Service, click the `+` button:
 


### PR DESCRIPTION
The how-to stated, that only one Public Service is needed, if multiple domains share the same ip. This is true, if we talk about the same port. If we have different ports, afaik we need one Public Service for each port. Elaborated a little on the description, to make it clearer.