### PR TITLE
vim-tiny was renamed vim-console

### DIFF
--- a/source/development/workflow.rst
+++ b/source/development/workflow.rst
@@ -122,7 +122,7 @@ there’s a couple optional of packages that help you to be productive:
 
 ::
 
-    # pkg install vim-lite joe nano gnu-watch git tmux screen
+    # pkg install vim-console joe nano gnu-watch git tmux screen
 
 The most important one is *git* for obtaining the code, the rest is
 optional if you need it—mostly editors and terminal wrappers. It is also


### PR DESCRIPTION
Replace reference to the `vim-tiny` package that was renamed to `vim-console` about 3 years ago.