### PR TITLE
Correcting mismatched interfaces in upload rule

### DIFF
--- a/source/manual/how-tos/shaper_guestnet.rst
+++ b/source/manual/how-tos/shaper_guestnet.rst
@@ -108,8 +108,8 @@ Create a rule for the upload traffic
 
 ====================== =================== =====================================================
  **sequence**            21                 *Auto generated number, overwrite only when needed*
- **interface**           WAN                *Select the interface that matches your GuestNet*
- **interface2**          GuestNet           *Select the interface connected to the internet*
+ **interface**           GuestNet           *Select the interface that matches your GuestNet*
+ **interface2**          WAN                *Select the interface connected to the internet*
  **proto**               ip                 *Select the protocol, IP in our example*
  **source**              any                *The source address, leave on any*
  **src-port**            any                *The source port to shape, leave on any*


### PR DESCRIPTION
The names of the interfaces were in wrong order on the upload rule