### PR TITLE
git-backup: hint to cronjobs for shorter backup intervals

### DIFF
--- a/source/manual/git-backup.rst
+++ b/source/manual/git-backup.rst
@@ -55,8 +55,9 @@ we choose this loosely coupled method. Events which are yet unprocessed are bein
     remains active.
 
 On periodic intervals (the standard ones from the backup scheduler), the collected commits are pushed to the configured
-upstream repository. The regular backup procedure (which is also being triggered using the test button in the user interface)
-is responsible for initialising the empty local repository and configuring the upstream target.
+upstream repository. To shorten these default intervals, a custom cronjob (see :doc:`Settings </manual/settingsmenu>`) can be
+set up, selecting `Remote Backup` as the Command. The regular backup procedure (which is also being triggered using the test
+button in the user interface) is responsible for initialising the empty local repository and configuring the upstream target.
 
 .. Note::
 


### PR DESCRIPTION
From this topic https://forum.opnsense.org/index.php?topic=21639.0

There is no officially documented way of decreasing the default push period for git backups (which is apparently 24 hours). It's super easy to do by setting up a cronjob. So adding a note to the docs doesn't hurt :)