### PR TITLE
API: Add a note for postman users

### DIFF
--- a/source/development/api.rst
+++ b/source/development/api.rst
@@ -25,6 +25,10 @@ The $key and $secret parameters are used to pass the API credentials using curl.
     key=w86XNZob/8Oq8aC5r0kbNarNtdpoQU781fyoeaOBQsBwkXUt
     secret=XeD26XVrJ5ilAc/EmglCRC+0j2e57tRsjHwFepOseySWLM53pJASeTA3
 
+.. note::
+
+     When using Postman to test an API call, use the 'basic auth' authorization type. The $key and $secret parameters go into Username/Password respectively.
+
 Core API
 --------
 


### PR DESCRIPTION
It may not be directly obvious to NOT use the API key authorization method in Postman. Instead, basic auth is used.