### PR TITLE
Update git default push interval time to nightly

### DIFF
--- a/source/manual/git-backup.rst
+++ b/source/manual/git-backup.rst
@@ -54,7 +54,7 @@ we choose this loosely coupled method. Events which are yet unprocessed are bein
     Events are processed from the moment the initial backup is configured, when disabling backups, the (local) changelog itself
     remains active.
 
-Every night OPNsense will git push, the collected commits to the upstream repository.
+Git backup will push collected commits to the upstream repository nightly.
 To shorten this default interval, a custom cronjob (see :doc:`Settings </manual/settingsmenu#cron>`) can be
 set up, selecting `Remote Backup` as the Command. The regular backup procedure (which is also being triggered using the test
 button in the user interface) is responsible for initialising the empty local repository and configuring the upstream target.


### PR DESCRIPTION
Update git default push interval time to nightly, so its more clear for users.

Also updates the link to go to the cron section for the referenced page.