### PR TITLE
remove peer id from phase 1

### DIFF
--- a/source/manual/how-tos/ipsec-road.rst
+++ b/source/manual/how-tos/ipsec-road.rst
@@ -134,7 +134,6 @@ Phase 1 proposal (Authentication)
  **Authentication method**   Mutual PSK +Xauth      *Using a Pre-shared Key and Login*
  **Negotiation mode**        Agressive              *Select Aggressive*
  **My identifier**           My IP address          *Simple identification for fixed ip*
- **Peer identifier**         User distinguished     *Identification for peer*
  **Pre-Shared Key**          At4aDMOAOub2NwT6gMHA   *Random key*. **CREATE YOUR OWN!**
 =========================== ====================== ======================================
 


### PR DESCRIPTION
Peer ID got removed for Mobile Client's IPSec Phase 1 Configuration years ago (see [0dd120f](https://github.com/opnsense/core/commit/0dd120ff1aac446f0df9a3f82051b95b64eecf27)), because the value is not used in the ipsec configuration.