### PR TITLE
Fixed Step 8 of manual/how-tos/wireguard-selective-routing: Destination / Invert | Unchecked

### DIFF
--- a/source/manual/how-tos/wireguard-selective-routing.rst
+++ b/source/manual/how-tos/wireguard-selective-routing.rst
@@ -178,7 +178,7 @@ It should be noted, however, that if the hosts that will use the tunnel are conf
      **Protocol**                 *any*
      **Source / Invert**          *Unchecked*
      **Source**                   *Select the relevant hosts Alias you created above in the dropdown (eg* :code:`WG_VPN_Hosts` *)*
-     **Destination / Invert**     *Checked*
+     **Destination / Invert**     *Unchecked*
      **Destination**              *Select the* :code:`RFC1918_Networks` *Alias you created above in the dropdown*
      **Destination port range**   *any*
      **Description**              *Add one if you wish to*


### PR DESCRIPTION
After wondering about why my wireguard routing was not working, I figured out, that in Step 8 of manual/how-tos/wireguard-selective-routing in the residing Interface rule it states:
Destination / Invert | Checked
Wich does not work. It has to be uncheck, thats what I changed.
