### PR TITLE
Update firmware.rst

### DIFF
--- a/source/development/api/core/firmware.rst
+++ b/source/development/api/core/firmware.rst
@@ -14,6 +14,7 @@ OPNsense has several API calls to get and set the firmware configuration:
    "``POST``","Core","Firmware","setFirmwareConfig",""
    "``GET``","Core","Firmware","info",""
    "``GET``","Core","Firmware","status",""
+   "``POST``","Core","Firmware","status",""
    "``POST``","Core","Firmware","audit",""
    "``POST``","Core","Firmware","update",""
    "``POST``","Core","Firmware","upgrade",""


### PR DESCRIPTION
POST is needed for core/firmware/status to check for updates
GET will only show updates if the WebUI button "check for updates" was used previously (or a POST request was sent)
-> a description column in the API tables would be helpful so that the two cases could be listed