### PR TITLE
Added hint for "client specific overrides"

### DIFF
--- a/source/manual/how-tos/sslvpn_s2s.rst
+++ b/source/manual/how-tos/sslvpn_s2s.rst
@@ -7,6 +7,11 @@ traffic to be routed between the two networks. This is most commonly used to
 connect an organization's branch offices back to its main office, so branch users
 can access network resources in the main office.
 
+.. Note::
+
+    When using the site to site example with :code:`SSL/TLS` instead of a shared key, make sure to configure "client specific overrides"
+    as well to correctly bind the remote networks to the correct client.
+    
 ----------------
 Before you start
 ----------------


### PR DESCRIPTION
I totally tripped over those "missing" lines.
I know it is said in the manual, but most google matches will lead directly to the how-to. 
It took me way to long to find the "bug" so this little Hint should prevent others from the same mistake.

Cheers Jochen