### PR TITLE
Additional info about Virtual IPs of type Other

### DIFF
--- a/source/manual/firewall_vip.rst
+++ b/source/manual/firewall_vip.rst
@@ -69,7 +69,8 @@ Other
 ..................
 
 The **other** type won't respond to ICMP ping messages or reply to ARP requests, it merely is a definition of an
-address (or range) which can be used in NAT rules.
+address (or range) which can be used in NAT rules. This is convenient when the firewall has a public IP block routed
+to its WAN IP address, IP Alias, or a CARP VIP.
 
 
 --------------------


### PR DESCRIPTION
This sentence from pfsense docs helped me realize I should use type Other instead of IP Alias for a subnet that's routed to my WAN IP address.