### PR TITLE
Explain automatic nightly remote backup in cloud_backup.rst

### DIFF
--- a/source/manual/how-tos/cloud_backup.rst
+++ b/source/manual/how-tos/cloud_backup.rst
@@ -51,7 +51,7 @@ algorithm used in the manual backup so it's quite easy to restore to a new
 installed machine.
 
 After set-up, the backup feature will run a first backup of the OPNsense
-configuration file. Then, if the configuration is subsequently changed, a new backup will be run once per day early in the morning (1:00am).
+configuration file. Then, if the configuration is subsequently changed, a new backup will be run once per day early in the morning.
 
 You may consider specifying additional Cronjobs when more frequent remote backup or remote backups at different times of the day would be required.
 

--- a/source/manual/how-tos/cloud_backup.rst
+++ b/source/manual/how-tos/cloud_backup.rst
@@ -51,7 +51,9 @@ algorithm used in the manual backup so it's quite easy to restore to a new
 installed machine.
 
 After set-up, the backup feature will run a first backup of the OPNsense
-configuration file. Then, if the configuration is subsequently changed, a new backup will be run. Only one backup is run per day after configuration changes.
+configuration file. Then, if the configuration is subsequently changed, a new backup will be run once per day early in the morning (1:00am).
+
+You may consider specifying additional Cronjobs when more frequent remote backup or remote backups at different times of the day would be required.
 
 ----------------------
 Setup Google API usage

--- a/source/manual/how-tos/cloud_backup.rst
+++ b/source/manual/how-tos/cloud_backup.rst
@@ -53,7 +53,7 @@ installed machine.
 After set-up, the backup feature will run a first backup of the OPNsense
 configuration file. Then, if the configuration is subsequently changed, a new backup will be run once per day early in the morning.
 
-You may consider specifying additional Cronjobs when more frequent remote backup or remote backups at different times of the day would be required.
+You may consider specifying additional Cronjobs when more frequent remote backups or remote backups at different times of the day would be required.
 
 ----------------------
 Setup Google API usage


### PR DESCRIPTION
Explain the automatic nightly remote backup in more detail, and also explain that additional Cronjobs will only be required when either more frequent backups or backups at another time of the day would be required.

Per discussion in:  https://github.com/opnsense/core/issues/5931