### PR TITLE
Adjust template doc to match current code style

### DIFF
--- a/source/development/backend/templates.rst
+++ b/source/development/backend/templates.rst
@@ -134,10 +134,10 @@ configd, to use (or test) the system without the daemon, use:
     from modules import config
      
     # construct a new template object, set root to /tmp/
-    tmpl = template.Template(target_root_directory="/tmp/")
+    tmpl = template.Template(target_root_directory='/tmp/')
     # open the config.xml and bind to template object
     conf = config.Config('/config.xml')
-    tmpl.setConfig(conf.get())
+    tmpl.set_config(conf.get())
      
     # generate output for OPNsense/Sample
     generated_filenames = tmpl.generate('OPNsense/Sample')


### PR DESCRIPTION
Small changes, my first open source contribution 🙂

Code style seems to have changed at some point from camelCase to kebab_case (https://github.com/opnsense/core/commit/9c84f2b4354ef3ebbe82f5886c8a762c48f3a71d#diff-71d92e6be8a9c0a91cc33757445094c40221198a8d8c171609aa860142f0cba2R120), documentation using "setConfig" was behind.

Also, changed a set of double quotes to single, following "pick a rule and stick to it" from https://peps.python.org/pep-0008/#string-quotes; all other strings I could see in the source and in the doc had single quotes.