### PR TITLE
add kernel src tree to build tool opnsense-code

### DIFF
--- a/source/manual/software_included.rst
+++ b/source/manual/software_included.rst
@@ -77,7 +77,7 @@ It's best to use our build system to facilitate this, you can do so using the fo
 
 .. code-block:: sh
 
-    opnsense-code ports tools
+    opnsense-code src ports tools
     cd /usr/ports/your/port
     make install
 
@@ -86,7 +86,7 @@ To update a package, the following command can be used instead:
 
 .. code-block:: sh
 
-    opnsense-code ports tools
+    opnsense-code src ports tools
     cd /usr/ports/your/port
     make reinstall
 


### PR DESCRIPTION
when I tried to build the port sysutils/acpi_call, it appears to require kernel src tree as well