### PR TITLE
firewall.rst: make 'os-firewall' dependency explicit, explain the lack of support for legacy rules 

### DIFF
--- a/source/development/api/core/firewall.rst.in
+++ b/source/development/api/core/firewall.rst.in
@@ -1,0 +1,22 @@
+.. _api_core_firewall:
+
+.. note::
+
+    As you may have noticed, this API does not provide access to the firewall rules themselves. For that, you will need to use
+    the :ref:`Firewall Plugin API <api_plugins_firewall>`.
+
+{{ title }}
+{{ title_underline }}
+{% for controller in controllers %}
+.. csv-table:: {{controller.type}} ({{controller.filename}})
+   :header: "Method", "Module", "Controller", "Command", "Parameters"
+   :widths: 4, 15, 15, 30, 40
+{%     for endpoint in controller.endpoints %}
+    "``{{endpoint.method}}``","{{endpoint.module}}","{{endpoint.controller}}","{{endpoint.command}}","{{endpoint.parameters}}"
+{%-    endfor %}
+{%-    if controller.uses %}
+{%         for use in controller.uses %}
+    "``<<uses>>``", "", "", "", "*{{use.type}}* `{{use.name}} <{{use.link}}>`__"
+{%-        endfor %}
+{%-    endif %}
+{% endfor %}

--- a/source/development/api/plugins/firewall.rst.in
+++ b/source/development/api/plugins/firewall.rst.in
@@ -1,9 +1,23 @@
+.. _api_plugins_firewall:
+
 {{ title }}
 {{ title_underline }}
 
-The firewall API plugin is a first step into migrating the legacy firewall components from OPNsense, although it does contain
-a user interface, it's main focus is only to provide machine to machine interaction between custom applications and OPNsense
-for selected features.
+.. note::
+
+    This API does not provide access the rules added using the existing legacy Core firewall, e.g. in :menuselection:`Firewall --> NAT`
+    or :menuselection:`Firewall --> Rules`. Instead, you can only access the rules that were added directly using this API or its own
+    UI in :menuselection:`Firewall --> Automation`.
+
+.. note::
+
+    The legacy :ref:`Core firewall API <api_core_firewall>` provides some additional methods.
+
+The firewall plugin can be installed by going to :menuselection:`System --> Firmware --> Plugins` and choosing
+**os-firewall**. It currently offers a limited functionality, but is eventually going to fully replace the existing, legacy
+firewall, shipped by OPNSense Core. Although the plugin already contains a basic user interface in :menuselection:`Firewall --> Automation`,
+its current main focus is to provide a machine to machine API interaction between custom applications and OPNsense.
+
 
 {% for controller in controllers %}
 .. csv-table:: {{controller.type}} ({{controller.filename}}) {% if not controller.is_abstract %} -- extends : {{controller.base_class}} {% endif %}


### PR DESCRIPTION
Explicitly mention the 'os-firewall' plugin dependency for the API to work. 

Also explain that it doesn't allow to access legacy rules.

Also fix some phrasing, grammar.

Fixes #436
Fixes opnsense/plugins#1898