### PR TITLE
Add privileges/authorization info to the API

### DIFF
--- a/collect_api_endpoints.in
+++ b/collect_api_endpoints.in
@@ -2,10 +2,10 @@
 {{ title_underline }}
 {% for controller in controllers %}
 .. csv-table:: {{controller.type}} ({{controller.filename}})
-   :header: "Method", "Module", "Controller", "Command", "Parameters"
-   :widths: 4, 15, 15, 30, 40
+   :header: "Method", "Module", "Controller", "Command", "Parameters", "Privilege required"
+   :widths: 4, 15, 15, 30, 40, 40
 {%     for endpoint in controller.endpoints %}
-    "``{{endpoint.method}}``","{{endpoint.module}}","{{endpoint.controller}}","{{endpoint.command}}","{{endpoint.parameters}}"
+    "``{{endpoint.method}}``","{{endpoint.module}}","{{endpoint.controller}}","{{endpoint.command}}","{{endpoint.parameters}}","{{', '.join(endpoint.acl_names)}}"
 {%-    endfor %}
 {%-    if controller.uses %}
 {%         for use in controller.uses %}

--- a/source/development/api.rst
+++ b/source/development/api.rst
@@ -18,6 +18,9 @@ There are two HTTP verbs used in the OPNsense API:
 
 The body of the HTTP POST request and response is an 'application/json' object.
 
+Authentication
+--------------
+
 The $key and $secret parameters are used to pass the API credentials using curl. You need to set these parameters with your own API credentials before using them in the examples:
 
 .. code-block:: sh
@@ -28,6 +31,31 @@ The $key and $secret parameters are used to pass the API credentials using curl.
 .. note::
 
      When using Postman to test an API call, use the 'basic auth' authorization type. The $key and $secret parameters go into Username/Password respectively.
+
+Authorization
+-------------
+
+When using the API, the user for which the $key and $secret were issued, may require specific privileges granted to use the API modules and their controllers.
+Such privileges, if any, are explicitly mentioned in the API documentation, alongside each method.
+
+In case of doubts, however, you can grep through the source code. For example, for the `sslh` module,
+the privileges can be found in https://github.com/opnsense/plugins/blob/master/net/sslh/src/opnsense/mvc/app/models/OPNsense/Sslh/ACL/ACL.xml (you may need to choose a tag that is relevant to the OPNsense version you use).
+
+The corresponding privilege name that needs to be granted is denoted by the `<name>` element. For the `sslh` module and "any" controller (as denoted by the "`/*`" wildcard),
+it is `Services: SSLH`:
+
+.. code-block:: xml
+
+    <acl>
+       <page-services-sslh>
+          <name>Services: SSLH</name>
+          <patterns>
+             <pattern>ui/sslh/*</pattern>
+             <pattern>api/sslh/*</pattern>
+          </patterns>
+      </page-services-sslh>
+    </acl>
+
 
 Core API
 --------


### PR DESCRIPTION
This adds information about the required privileges to the API pages. Uses the corresponding ACL.xml, if found in the source code. 