### PR TITLE
added warning about high priority of nat rules

### DIFF
--- a/source/manual/firewall.rst
+++ b/source/manual/firewall.rst
@@ -122,7 +122,8 @@ Our default deny rule uses this property for example (if no rule applies, drop t
 
 .. Warning::
 
-    `NAT : port forwarding rules <nat.html#port-forwarding>`__ are registered using a priority of 600, i.e. at a very high priority. This has the consequence, that if you use a NAT : port forwarding rule *without a associated rule*, i.e. **Filter rule association** set to **Pass**, no other rules will apply!
+    **NAT rules are always processed before filter rules!**
+    For example `NAT : port forwarding rules <nat.html#port-forwarding>`__ are registered using a priority of 600, i.e. at a very high priority. This has the consequence, that if you use a NAT : port forwarding rule *without a associated rule*, i.e. **Filter rule association** set to **Pass**, no other rules will apply!
 
 .. Tip::
 

--- a/source/manual/firewall.rst
+++ b/source/manual/firewall.rst
@@ -120,6 +120,10 @@ Our default deny rule uses this property for example (if no rule applies, drop t
     groups use :code:`300000` and interface rules land on :code:`400000` combined with the order in which they appear.
     Automatic rules are usually registered at a higher priority (lower number).
 
+.. Warning::
+
+    `NAT : port forwarding rules <nat.html#port-forwarding>`__ are registered using a priority of 600, i.e. at a very high priority. This has the consequence, that if you use a NAT : port forwarding rule *without a associated rule*, i.e. **Filter rule association** set to **Pass**, no other rules will apply!
+
 .. Tip::
 
     The interface should show all rules that are used, when in doubt, you can always inspect the raw output of the ruleset in :code:`/tmp/rules.debug`

--- a/source/manual/firewall.rst
+++ b/source/manual/firewall.rst
@@ -123,7 +123,7 @@ Our default deny rule uses this property for example (if no rule applies, drop t
 .. Warning::
 
     **NAT rules are always processed before filter rules!**
-    For example `NAT : port forwarding rules <nat.html#port-forwarding>`__ are registered using a priority of 600, i.e. at a very high priority. This has the consequence, that if you use a NAT : port forwarding rule *without a associated rule*, i.e. **Filter rule association** set to **Pass**, no other rules will apply!
+    So for example, if you define a `NAT : port forwarding rules <nat.html#port-forwarding>`__  *without a associated rule*, i.e. **Filter rule association** set to **Pass**, this has the consequence, that no other rules will apply!
 
 .. Tip::
 


### PR DESCRIPTION
added a **warning** regarding the high prio of nat port forwarding rules and the consequences regarding port forwarding rules without a associated rule.