### PR TITLE
Update "first" WireGuard instance number

### DIFF
--- a/source/manual/how-tos/wireguard-client.rst
+++ b/source/manual/how-tos/wireguard-client.rst
@@ -102,7 +102,7 @@ Step 5(a) - Assign an interface to WireGuard (recommended)
     Finally, it allows separation of the firewall rules of each WireGuard instance (each :code:`wgX` device). Otherwise they all need to be configured on the default WireGuard group that OPNsense creates. This is more an organisational aesthetic, rather than an issue of substance    
 
 - Go to :menuselection:`Interfaces --> Assignments`
-- In the dropdown next to “New interface:”, select the WireGuard device (:code:`wg0` if this is your first one)
+- In the dropdown next to “New interface:”, select the WireGuard device (:code:`wg1` if this is your first one)
 - Add a description (eg :code:`HomeWireGuard`)
 - Click **+** to add it, then click **Save**
 - Then select your new interface under the Interfaces menu


### PR DESCRIPTION
The doc references `wg0` as the "first" WireGuard instance; however, this appears to have changed last year, **perhaps inadvertently**, to `wg1`.

I can't find anything referencing this as a problem, but am hoping this doc change PR can serve as a quick confirmation that the change from `wg0` to `wg1` was intended.

---
The following two changes together affected the default instance, so this first changed in 22.7 (assuming I did my git archaeology correctly).

Removed min/max on the plugin's `server->instance` field (22.1):
https://github.com/opnsense/plugins/pull/2760

> [you should be safe, 0 is the default](https://github.com/opnsense/plugins/pull/2760#discussion_r789547565)

Changed `AutoNumberField` default minimum from 0 to 1 (22.7):
https://github.com/opnsense/core/commit/09d782f8f53e169a71b4d800c3325f98de3b2834