### PR TITLE
Update terminology on Wireguard how-to pages

### DIFF
--- a/source/manual/how-tos/wireguard-client-azire.rst
+++ b/source/manual/how-tos/wireguard-client-azire.rst
@@ -30,16 +30,16 @@ favorite text editor.
 Step 2 - Setup WireGuard Instance
 ----------------------------------
 
-Go to tab **Local** and create a new instance. Give it a **Name** and set a desired **Listen Port**. 
+Go to tab **Instances** and create a new instance. Give it a **Name** and set a desired **Listen Port**. 
 If you have more than one server instance be aware that you can use the **Listen Port** only once. In 
 the field **Private Key** insert the value from your text file and leave **Public Key** empty. **DNS** 
-and **Tunnel Address** has also to be taken from the configuration. Hit **Save** and go to **Endpoint** 
+and **Tunnel Address** has also to be taken from the configuration. Hit **Save** and go to **Peers** 
 tab.
 
-On **Endpoint** tab create a new Endpoint, give it a **Name**, set 0.0.0.0/0 in **Allowed IPs** and set
+On **Peers** tab create a new Peer, give it a **Name**, set 0.0.0.0/0 in **Allowed IPs** and set
 the DNS name from your configuration in **Endpoint Address**. Don't forget to do this also for the port.
 
-Go back to tab **Local**, open the instance and choose the newly created endpoint in **Peers**.
+Go back to tab **Instances**, open the instance and choose the newly created peer in **Peers**.
 
 Now we can **Enable** the VPN in tab **General** and continue with the setup.
 

--- a/source/manual/how-tos/wireguard-client-mullvad.rst
+++ b/source/manual/how-tos/wireguard-client-mullvad.rst
@@ -14,7 +14,7 @@ you have read the basic howto :doc:`wireguard-client`.
 Step 1 - Setup WireGuard Instance
 ----------------------------------
 
-Go to tab **Local** and create a new instance. Give it a **Name** and set a desired **Listen Port**. 
+Go to tab **Instances** and create a new instance. Give it a **Name** and set a desired **Listen Port**. 
 If you have more than one server instance be aware that you can use the **Listen Port** only once. In 
 the field **Tunnel Address** insert an unsused private IP address and subnet mask. We don't need it in
 the first step, but as it is required we can't go on without it. Every other field can be left blank.
@@ -23,7 +23,7 @@ Hit **Save** and open your instance again to write down your public key. You nee
 of the configuration from the Mullvad API servers. 
 
 Now change to your OPNsense CLI via SSH or Console and execute *either* of the curl strings below. Please replace
-**YOURACCOUNTNUMBER** with your own ID you got from MullvadVPN and **YOURPUBLICKEY** with the one in your **Local**
+**YOURACCOUNTNUMBER** with your own ID you got from MullvadVPN and **YOURPUBLICKEY** with the one in your **Instances**
 
 The command below is for Mullvad's standard API. DNS requests through a tunnel that uses tunnel IPs generated via this API are "hijacked", so that Mullvad's DNS servers are used to avoid leaks:
 
@@ -37,10 +37,10 @@ The alternative command below is for Mullvad's other API. DNS requests through t
 
 	curl -sSL https://api.mullvad.net/app/v1/wireguard-keys -H "Content-Type: application/json" -H "Authorization: Token YOURACCOUNTNUMBER" -d '{"pubkey":"YOURPUBLICKEY"}'
     
-What you receive is what WireGuard calls **Allowed IP** for your local instance. Edit your instance again and remove
+What you receive is what WireGuard calls **Allowed IP** for your WireGuard Instance. Edit your instance again and remove
 the value of **Tunnel Address** you used when setting it up and change it to the one you got.
 
-On **Endpoint** tab create a new Endpoint, give it a **Name**, set 0.0.0.0/0 in **Allowed IPs** and set
+On **Peers** tab create a new Peer, give it a **Name**, set 0.0.0.0/0 in **Allowed IPs** and set
 the **DNS** to 193.138.218.74. This is the one MulladVPN provides for privacy.
 
 Now go to the WireGuard server list_ and choose the one you like to use as your breakout. Write down it's
@@ -50,7 +50,7 @@ Also do not forget **Endpoint Address** and **Endpoint Port**. The **Endpoint Po
 
 .. _list: https://www.mullvad.net/en/servers/#wireguard
 
-Go back to tab **Local**, open the instance and choose the newly created endpoint in **Peers**.
+Go back to tab **Instances**, open the instance and choose the newly created peer in **Peers**.
 
 Now we can **Enable** the VPN in tab **General** and continue with the setup.
 

--- a/source/manual/how-tos/wireguard-client.rst
+++ b/source/manual/how-tos/wireguard-client.rst
@@ -8,7 +8,7 @@ Introduction
 
 WireGuard is a simple, fast VPN protocol using modern `cryptography <https://www.wireguard.com/protocol>`__. It aims to be faster and less complex than IPsec whilst also being a considerably more performant alternative to OpenVPN. Initially released for the Linux kernel, it is now cross-platform and widely deployable.
 
-This how-to describes setting up a central WireGuard server on OPNsense and configuring one or more clients to create a tunnel to it. 
+This how-to describes setting up a central WireGuard Instance (server) on OPNsense and configuring one or more client peers to create a tunnel to it. 
 
 -------------------------------------
 Step 1 - Install the WireGuard plugin
@@ -18,12 +18,12 @@ Step 1 - Install the WireGuard plugin
 - Once the plugin is installed, refresh the browser page and you will find the WireGuard configuration menu via :menuselection:`VPN --> WireGuard`.
 
 ------------------------------------------
-Step 2 - Configure the local peer (server)
+Step 2 - Configure the Wireguard Instance
 ------------------------------------------
 
-- Go to :menuselection:`VPN --> WireGuard --> Local`
-- Click **+** to add a new Local configuration
-- Configure the Local configuration as follows (if an option is not mentioned below, leave it as the default):
+- Go to :menuselection:`VPN --> WireGuard --> Instances`
+- Click **+** to add a new Instance configuration
+- Configure the Instance configuration as follows (if an option is not mentioned below, leave it as the default):
 
     ===================== ===============================================================================================
      **Enabled**           *Checked*
@@ -33,7 +33,7 @@ Step 2 - Configure the local peer (server)
      **Listen Port**       *51820 or a higher numbered unique port*
      **MTU**               *1420 (default) or 1412 if you use PPPoE; it's 80 bytes less than your WAN MTU*
      **Tunnel Address**    *For example, 10.10.10.1/24. See note below*
-     **Peers**             *The (client) peers will be specified here; leave it blank initially until the Endpoint configuration is created in Step 3*
+     **Peers**             *The (client) peers will be specified here; leave it blank initially until the Peer configuration is created in Step 3*
      **Disable Routes**    *Unchecked*
     ===================== ===============================================================================================
 
@@ -45,31 +45,31 @@ Step 2 - Configure the local peer (server)
 
     Leave the DNS Server field (which appears if :code:`advanced mode` is selected) blank. Otherwise WireGuard will overwrite OPNsense's DNS configuration
 
-- **Save** the Local peer configuration, and then click **Save** again
-- Re-open the Local peer configuration
+- **Save** the Instance configuration, and then click **Save** again
+- Re-open the Instance configuration
 - Copy the public key that has been generated in the configuration. This will be needed for the client device - see Step 7
 - **Save** or **Cancel** to exit the configuration
 
 ---------------------------------------------
-Step 3 - Configure the endpoint (client peer)
+Step 3 - Configure the client peer
 ---------------------------------------------
 
-- Go to :menuselection:`VPN --> WireGuard --> Endpoints`
-- Click **+** to add a new Endpoint
-- Configure the Endpoint as follows (if an option is not mentioned below, leave it as the default):
+- Go to :menuselection:`VPN --> WireGuard --> Peers`
+- Click **+** to add a new Peer
+- Configure the Peer as follows (if an option is not mentioned below, leave it as the default):
 
     ====================== ====================================================================================================
      **Enabled**            *Checked*
      **Name**               *Call it whatever you want (eg* :code:`Phone` *)*
      **Public Key**         *Insert the public key from the client; if needed skip ahead and start Step 7 to generate the client public key*
-     **Allowed IPs**        *Unique tunnel IP address (IPv4 and/or IPv6) of client - it should be a /32 or /128 (as applicable) within the subnet configured on the local peer. For example, 10.10.10.2/32*
+     **Allowed IPs**        *Unique tunnel IP address (IPv4 and/or IPv6) of client - it should be a /32 or /128 (as applicable) within the subnet configured on the WireGuard Instance. For example, 10.10.10.2/32*
     ====================== ====================================================================================================
 
-- **Save** the Endpoint configuration, and then click **Save** again
-- Now go back to :menuselection:`VPN --> WireGuard --> Local`
-- Open the Local configuration that was created in Step 1 (eg :code:`HomeWireGuard`)
-- In the Peers dropdown, select the newly created Endpoint (eg :code:`Phone`)
-- **Save** the Local peer configuration again, and then click **Save** once more
+- **Save** the Peer configuration, and then click **Save** again
+- Now go back to :menuselection:`VPN --> WireGuard --> Instances`
+- Open the Instance configuration that was created in Step 1 (eg :code:`HomeWireGuard`)
+- In the Peers dropdown, select the newly created Peer (eg :code:`Phone`)
+- **Save** the Instance configuration again, and then click **Save** once more
 - Repeat this Step 3 for as many clients as you wish to configure
 
 ----------------------------------
@@ -119,7 +119,7 @@ Step 5(a) - Assign an interface to WireGuard (recommended)
 
 .. Note::
 
-    There is no need to configure IPs on the interface. The tunnel address(es) specified in the Local configuration for your WireGuard server will be automatically assigned to the interface once WireGuard is restarted
+    There is no need to configure IPs on the interface. The tunnel address(es) specified in the Instance configuration for your server will be automatically assigned to the interface once WireGuard is restarted
 
 - **Save** the interface configuration and then click **Apply changes**
 - Restart WireGuard - you can do this by turning it off and on under :menuselection:`VPN --> WireGuard --> General` (click **Apply** after both unchecking and checking the checkbox)
@@ -163,7 +163,7 @@ Step 5(b) - Create an outbound NAT rule
 
 .. Hint::
 
-    If you didn't assign an interface as suggested in Step 5(a), then you will need to manually specify the source IPs/subnet(s) for the tunnel (for example, 10.10.10.0/24). It's probably easiest to define an alias (via :menuselection:`Firewall --> Aliases`) for those IPs/subnet(s) and use that. If you have only one local WireGuard instance and only one WireGuard endpoint configured, you can use the default :code:`WireGuard net`, although this is generally not recommended due to unexpected behaviour
+    If you didn't assign an interface as suggested in Step 5(a), then you will need to manually specify the source IPs/subnet(s) for the tunnel (for example, 10.10.10.0/24). It's probably easiest to define an alias (via :menuselection:`Firewall --> Aliases`) for those IPs/subnet(s) and use that. If you have only one WireGuard Instance and only one WireGuard Peer configured, you can use the default :code:`WireGuard net`, although this is generally not recommended due to unexpected behaviour
 
 ------------------------------
 Step 6 - Create firewall rules
@@ -186,7 +186,7 @@ This will involve two steps - first creating a firewall rule on the WAN interfac
      **Source**                   *any*
      **Destination / Invert**     *Unchecked*
      **Destination**              *WAN address*
-     **Destination port range**   *The WireGuard port specified in the Local configuration in Step 2*
+     **Destination port range**   *The WireGuard port specified in the Instance configuration in Step 2*
      **Description**              *Add one if you wish to*
     ============================ ==================================================================================================
 
@@ -214,7 +214,7 @@ This will involve two steps - first creating a firewall rule on the WAN interfac
 
 .. Note::
 
-    If you didn't assign an interface as suggested in Step 5(a), then the second firewall rule outlined above will need to be configured on the automatically created :code:`WireGuard` group that appears once the Local configuration is enabled and WireGuard is started. You will also need to manually specify the source IPs/subnet(s) for the tunnel. It's probably easiest to define an alias (via :menuselection:`Firewall --> Aliases`) for those IPs/subnet(s) and use that. If you have only one local WireGuard instance and only one WireGuard endpoint configured, you can use the default :code:`WireGuard net`, although this is generally not recommended due to unexpected behaviour
+    If you didn't assign an interface as suggested in Step 5(a), then the second firewall rule outlined above will need to be configured on the automatically created :code:`WireGuard` group that appears once the Instance configuration is enabled and WireGuard is started. You will also need to manually specify the source IPs/subnet(s) for the tunnel. It's probably easiest to define an alias (via :menuselection:`Firewall --> Aliases`) for those IPs/subnet(s) and use that. If you have only one WireGuard Instance and only one WireGuard Peer configured, you can use the default :code:`WireGuard net`, although this is generally not recommended due to unexpected behaviour
     
 ------------------------------------
 Step 6a - Create normalization rules
@@ -269,13 +269,13 @@ Client configuration is largely beyond the scope of this how-to since there is s
 
     ====================== ====================================================================================================
      **[Interface]**
-     **Address**            *Refers to the IP(s) specified as Allowed IPs in the Endpoint configuration on OPNsense. For example, 10.10.10.2/32*
-     **PublicKey**          *Refers to the public key that (along with a private key) needs to be manually or automatically generated on the client. The public key must then be copied into the Endpoint configuration on OPNsense for the relevant client peer - see Step 3*
+     **Address**            *Refers to the IP(s) specified as Allowed IPs in the Peer configuration on OPNsense. For example, 10.10.10.2/32*
+     **PublicKey**          *Refers to the public key that (along with a private key) needs to be manually or automatically generated on the client. The public key must then be copied into the Peer configuration on OPNsense for the relevant client peer - see Step 3*
      **DNS**                *Refers to the DNS servers that the client should use for the tunnel - see note below*
 
      **[Peer]**
-     **PublicKey**          *Refers to the public key that is generated on OPNsense. Copy the public key from the Local configuration on OPNsense - see Step 2*
-     **Endpoint**           *Refers to the public IP address or publicly resolvable domain name of your OPNsense host, and the port specified in the Local configuration on OPNsense*
+     **PublicKey**          *Refers to the public key that is generated on OPNsense. Copy the public key from the Instance configuration on OPNsense - see Step 2*
+     **Endpoint**           *Refers to the public IP address or publicly resolvable domain name of your OPNsense host, and the port specified in the Instance configuration on OPNsense*
      **AllowedIPs**         *Refers to the traffic (by destination IPs/subnets) that is to be sent via the tunnel. For example, if all traffic on the client is to be sent through the tunnel, specify 0.0.0.0/0 (IPv4) and/or ::/0 (IPv6)*
     ====================== ====================================================================================================
 

--- a/source/manual/how-tos/wireguard-selective-routing.rst
+++ b/source/manual/how-tos/wireguard-selective-routing.rst
@@ -6,25 +6,25 @@ WireGuard Selective Routing to External VPN Endpoint
 Introduction
 ------------
 
-This how-to is designed to assist with setting up WireGuard on OPNsense to use selective routing to an external VPN endpoint - most commonly to an external VPN provider.
+This how-to is designed to assist with setting up WireGuard on OPNsense to use selective routing to an external VPN peer - most commonly to an external VPN provider.
 
 These circumstances may apply where only certain local hosts are intended to use the VPN tunnel. Or it could apply where multiple connections to the VPN provider are desired, with each connection intended to be used by different specific local hosts.
 
 This how-to focuses on the configuration of OPNsense. You will also have to configure the peer at your VPN provider - consult your VPN provider’s documentation as to how to do that.
 
-Your OPNsense local public key will need to be registered with your VPN provider, and you will need to get your VPN provider’s endpoint public key and the VPN tunnel IP provided for your local peer by your VPN provider. In some cases, you will not be able to get the endpoint public key and VPN tunnel IP until you register your local public key. In that case, create the OPNsense local configuration first, using a dummy tunnel IP and no peer selected, so that the public key is generated, and then update the configuration later once the other information is known.
+Your OPNsense WireGuard Instance public key will need to be registered with your VPN provider, and you will need to get your VPN provider’s endpoint public key and the VPN tunnel IP provided for your WireGuard Instance by your VPN provider. In some cases, you will not be able to get the Peer public key and VPN tunnel IP until you register your WireGuard Instance public key. In that case, create the OPNsense Instance configuration first, using a dummy tunnel IP and no peer selected, so that the public key is generated, and then update the configuration later once the other information is known.
 
 For an example of configuring the peer at a VPN provider (Mullvad), see Step 1 of the how-to :doc:`wireguard-client-mullvad`.
 
 This how-to primarily focuses on IPv4 configuration. It can be readily adapted for IPv6 as well. See :ref:`configuring-ipv6` below.
 
 -------------------------------
-Step 1 - Configure the endpoint
+Step 1 - Configure the peer
 -------------------------------
 
-- Go to :menuselection:`VPN --> WireGuard --> Endpoints`
-- Click **+** to add a new Endpoint
-- Configure the Endpoint as follows (if an option is not mentioned below, leave it as the default):
+- Go to :menuselection:`VPN --> WireGuard --> Peers`
+- Click **+** to add a new Peer
+- Configure the Peer as follows (if an option is not mentioned below, leave it as the default):
 
     ====================== ====================================================================================================
      **Enabled**            *Checked*
@@ -36,16 +36,16 @@ Step 1 - Configure the endpoint
      **Keepalive**          *25*
     ====================== ====================================================================================================
 
-- **Save** the Endpoint configuration, and then click **Save** again
+- **Save** the Peer configuration, and then click **Save** again
 
 ---------------------------------
-Step 2 - Configure the local peer
+Step 2 - Configure the WireGuard Instance
 ---------------------------------
 
-- Go to :menuselection:`VPN --> WireGuard --> Local`
-- Click **+** to add a new Local configuration
+- Go to :menuselection:`VPN --> WireGuard --> Instances`
+- Click **+** to add a new Instance configuration
 - Turn on “advanced mode"
-- Configure the Local configuration as follows (if an option is not mentioned below, leave it as the default):
+- Configure the Instance configuration as follows (if an option is not mentioned below, leave it as the default):
 
     ===================== ===============================================================================================
      **Enabled**           *Checked*
@@ -54,8 +54,8 @@ Step 2 - Configure the local peer
      **Private Key**       *This will initially be blank; it will be populated once the configuration is saved*
      **Listen Port**       *51820 or a higher numbered unique port*
      **DNS Server**        *Leave this blank, otherwise WireGuard will overwrite OPNsense's DNS configuration*
-     **Tunnel Address**    *Insert the local VPN tunnel IP provided by your VPN provider, in CIDR format, eg 10.24.24.10/32*
-     **Peers**             *In the dropdown, select the Endpoint you configured above*
+     **Tunnel Address**    *Insert the WireGuard Instance VPN tunnel IP provided by your VPN provider, in CIDR format, eg 10.24.24.10/32*
+     **Peers**             *In the dropdown, select the Peer you configured above*
      **Disable Routes**    *Checked*
      **Gateway**           *Specify an IP that is 1 number below your VPN tunnel IP, eg 10.24.24.9 - see note below*
     ===================== ===============================================================================================
@@ -64,7 +64,7 @@ Step 2 - Configure the local peer
 
     The IP you choose for the Gateway is essentially arbitrary; pretty much any unique IP will do. The suggestion here is for convenience and to avoid conflicts
 
-- **Save** the local peer configuration, and then click **Save** again
+- **Save** the Instance configuration, and then click **Save** again
 
 --------------------------
 Step 3 - Turn on WireGuard
@@ -112,7 +112,7 @@ Step 6 - Create a gateway
      **Description**                  *Add one if you wish to*
      **Interface**                    *Select your newly created interface in the dropdown*
      **Address Family**               *Select IPv4 in the dropdown*
-     **IP address**                   *Insert the gateway IP that you configured under the WireGuard local peer configuration*
+     **IP address**                   *Insert the gateway IP that you configured under the WireGuard Instance configuration*
      **Far Gateway**                  *Checked*
      **Disable Gateway Monitoring**   *Unchecked*
      **Monitor IP**                   *Insert the endpoint VPN tunnel IP (NOT the public IP) of your VPN provider - see note below*
@@ -290,7 +290,7 @@ Some VPN providers (such as Mullvad) allow you to send both IPv4 and IPv6 traffi
 
 To configure the tunnel to use IPv6, you essentially need to replicate the steps above for IPv4. That is, you need to:
 
-- add the IPv6 tunnel IP to Tunnel Address on the WireGuard Local configuration (see further below)
+- add the IPv6 tunnel IP to Tunnel Address on the WireGuard Instance configuration (see further below)
 - add :code:`::/0` to the Allowed IPs on the WireGuard Endpoint configuration
 - create an IPv6 gateway (see further below)
 - add to the hosts alias the IPv6 addresses of the hosts/networks that are to use the tunnel
@@ -302,11 +302,11 @@ To configure the tunnel to use IPv6, you essentially need to replicate the steps
 
 Note, however, that there are a couple of differences:
 
-1. First, the WireGuard Local configuration will only accept one entry in the Gateway field. Just leave the IPv4 gateway address there.
+1. First, the WireGuard Instance configuration will only accept one entry in the Gateway field. Just leave the IPv4 gateway address there.
 
 2. Second, there is no concept of a Far Gateway for IPv6. So to successfully set up a gateway for IPv6, you need to do two things:
 
-  - When adding the IPv6 address to Tunnel Address in the WireGuard Local configuration, specify a /127 mask, rather than a /128
+  - When adding the IPv6 address to Tunnel Address in the WireGuard Instance configuration, specify a /127 mask, rather than a /128
   - Then, when creating an IPv6 Gateway for the tunnel, specify the IP address to be another IPv6 address that is within the /127 subnet of the Tunnel Address
 
 .. _dns-leaks:


### PR DESCRIPTION
Some time ago the name of some of the tabs in the WireGuard community plugin changed and the changes were not propagated in some pages. This mainly consists of renaming
Local peer -> WireGuard Instance
Endpoints -> Peers
This will close #515  