### PR TITLE
Fix typo in documentation/troubleshooting/webui.

### DIFF
--- a/source/troubleshooting/webgui.rst
+++ b/source/troubleshooting/webgui.rst
@@ -14,6 +14,6 @@ in case something went wrong while setting up anti lockout policies or after cha
     When logged in directly via a console or shell, you can also use the following command to generate a new self-signed certificate
     and restart the web ui:
 
-    :code:`configctl webgui restart renew``
+    :code:`configctl webgui restart renew`
 
 


### PR DESCRIPTION
Fix a small typo in the code section of the documentation ["Troubleshooting / WebGui access reset"](https://docs.opnsense.org/troubleshooting/webgui.html).

Haven't done any tests or builds!

Thanks for merging :)