### PR TITLE
Add link to docs repo to contributing section

### DIFF
--- a/source/contribute.rst
+++ b/source/contribute.rst
@@ -173,10 +173,10 @@ Documentation & wiki articles
 -----------------------------
 The easiest way to help with documentation is to write how-to type articles.
 As the wiki & documentation project itself is written in **reStructuredText** you
-can offer your content in this format (preferably as pull request), but other
-formats are also possible, such as:
+can offer your content in this format (preferably as a `pull request <https://github.com/opnsense/docs>`__).
+Other formats are also possible, such as:
 
-* markup with ./images/directory including the used images(in any)
+* markup with ./images/directory including the used images (if any)
 * word document with embedded images (if any)
 
 To include you documentation send it to contact @ opnsense.org. Make sure that:


### PR DESCRIPTION
This PR adds a link to this repo in the "Contributing" section.

I was reading the docs at https://docs.opnsense.org and found something I wanted to fix (#533). However, I had to manually go to Github and search for this repo. Having the link directly in the docs would have helped me to find it faster.

Disclaimer: i just edited the raw files, I haven't tried building the docs to HTML.