### PR TITLE
Hint sphinx-autobuild in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,15 @@ make html
 ```
 
 (```make clean``` to flush)
+
+#### Live preview of HTML documents
+
+Use `sphinx-autobuild` to track `source` for changes and get a live preview served via ``http://localhost:8000``.
+
+```
+pip[3] install sphinx-autobuild
+```
+
+```
+sphinx-autobuild source html
+```


### PR DESCRIPTION
Hint the use of sphinx-autobuild in Readme.md. It's a great tool to see a live preview while writing docs and editing them. The instant feedback really helps to get work done faster.

Maybe this can help some people, I use this all the time while writing docs.