### PR TITLE
Update sfp_compatibility.rst and ice driver tunable

### DIFF
--- a/source/hardware/sfp_compatibility.rst
+++ b/source/hardware/sfp_compatibility.rst
@@ -205,4 +205,5 @@ Uptimed   UP-SFP28-SR-CI                 25G
 Vendor    Type                           Speed   Notes
 ========= ============================== ======= =========================
 FlexOptix P.C3025G.H Passive             25G
+FS        SFP-H25G-CU1M                  25G     With Intel compatibility
 ========= ============================== ======= =========================


### PR DESCRIPTION
only worked after enabling the ice modules with the tunables. maybe add an information about this to the documentation. I only found this info in the forums. without the tunables i was only able to get a 10Gbase connection when setting the speed on the switch.

tunables:
if_ice_load="YES"
ice_ddp_load="YES"

reboot after setting the tunables. nothing more is needed.

source:
https://forum.opnsense.org/index.php?topic=30759.0