### PR TITLE
Update README.md - Update sphinx-autobuild command

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,5 +71,5 @@ pip[3] install sphinx-autobuild
 ```
 
 ```
-sphinx-autobuild source html
+sphinx-autobuild source build/html
 ```


### PR DESCRIPTION
Since `make clean` does `rm -rf build/*`, the `sphinx-autobuild` should happen in `build/html`.