### PR TITLE
Update reverse_proxy.rst and caddy.rst

### DIFF
--- a/source/manual/how-tos/caddy.rst
+++ b/source/manual/how-tos/caddy.rst
@@ -675,7 +675,9 @@ Custom Configuration Files
 
 * | The Caddyfile has an additional import from the path ``/usr/local/etc/caddy/caddy.d/``. Place custom configuration files inside that adhere to the Caddyfile syntax.
 * | ``*.global`` files will be imported into the global block of the Caddyfile.
-* | ``*.conf`` files will be imported at the end of the Caddyfile. Don't forget to test the custom configuration with ``caddy validate --config /usr/local/etc/caddy/Caddyfile``.
+* | ``*.conf`` files will be imported at the end of the Caddyfile.
+* | ``*.layer4`` files will be imported into the Layer4 directive of the Caddyfile.
+* | Don't forget to test the custom configuration with ``caddy validate --config /usr/local/etc/caddy/Caddyfile``.
 
 With these imports, the full potential of Caddy can be unlocked. The GUI options will remain focused on the reverse proxy. **There is no OPNsense community support for configurations that have not been created with the offered GUI**. For customized configurations, the Caddy community is the right place to ask.
 
@@ -763,6 +765,7 @@ With the `Matcher` `not SNI`, the `Client Hello` of the TLS traffic is analyzed.
 All other `TCP/UDP` traffic will be streamed to the chosen socket (Upstream Domain and Upstream Port). Since we chose multiple upstreams and a health check, two servers can load balance all requests. The load balancing is just an example, and not necessary for the `not SNI` matcher to work.
 
 .. Tip:: If there are domains inside `*.example.com` that should be routed to a different upstream, just create an additional `SNI Matcher` for them. It will automatically match before the `not SNI Matcher` - compare to the `Layer4 Routing Precedence`.
+.. Tip:: Caddy supports the HA Proxy Protocol. If the Protocol Header should be added to the upstream, set the `Proxy Protocol` version to ``v1`` or ``v2``.
 
 
 ======================
@@ -779,8 +782,8 @@ Help, Nothing Works!
 
 **This is what should happen if Caddy works correctly:**
 
-#. | A `User` opens a `Web Browser` and types the following into the address bar: `https://example.com`
-#. | The operating system of the `Web Browser` sends a request to the system `DNS Server`, and asks where to find `example.com`. The `DNS Server` will try to find the requested `A- and/or AAAA-Record` for that domain, and will answer with e.g. `203.0.113.1`.
+#. | A `Web Browser` is opened and an `URL` is put into the address bar: `https://example.com`
+#. | The underlying `Operating System` of the `Web Browser` sends a request to its default `DNS Server`, and asks where to find `example.com`. The `DNS Server` will try to find the requested `A- and/or AAAA-Record` for that domain, and will answer with e.g. `203.0.113.1`.
 #. | The `Web Browser` now sends a `HTTPS request` to `203.0.113.1`. This request contains a `Client Hello` in the TLS handshake, that contains `example.com`.
 #. | This `HTTPS request` hits port `443` of the OPNsense's `WAN` or `LAN` interface, determined by the location of the `Web Browser` (LAN or WAN).
 #. | There is a Firewall rule that allows destination port `443` to access `This Firewall`. The request will then be received by Caddy, because it listens on `This Firewall` on port `443`.
@@ -798,7 +801,7 @@ Help, Nothing Works!
 * Do `A- and/or AAAA-Record` for all `Domains` and `Subdomains` exist?
 * In case of activated `Dynamic DNS`, check that the correct `A- and/or AAAA-Records` have been set automatically with the DNS Provider.
 * Do they point to one of the external IPv4 or IPv6 addresses of the OPNsense Firewall? Check that with commands like ``nslookup example.com``.
-* Do the OPNsense `Firewall Rules` allow connections to destination ports `80` and `443` to access the destination `This Firewall`?
+* Do the OPNsense `Firewall Rules` allow connections from `any` source to destination ports `80` and `443` to the destination `This Firewall`?
 * Is the Caddy service running?
 
 **2. Check if the Domain is set up correctly:**

--- a/source/manual/how-tos/caddy.rst
+++ b/source/manual/how-tos/caddy.rst
@@ -701,7 +701,7 @@ Enable Layer4
 .. Tip::
     **Layer4 Routing Precedence** (automatic, order of listed items in bootgrid does not matter)
 
-    #. `SSH`
+    #. `SSH (and other protocols that can only match all traffic)`
     #. `HTTP (Host Header)`
     #. `TLS (SNI)`
     #. `TLS (inverted SNI)`
@@ -716,19 +716,10 @@ A matcher checks the first bytes of a TCP/UDP paket and decides which protocol i
 `Layer4 Routes` match before domains in the `Domains Tab`. That is why already existing domains can not be selected in a matcher. They have to be manually filled in. Multiple domains and even wildcards can be matched in the same `Layer4 Route`.
 
 
-HTTP (Host Header)
-------------------
+SSH, RDP, and other protocols
+-----------------------------
 
-Same logic as the `SNI` matcher, but can be used to route `HTTP` traffic, since the `Host Header` is evaluated.
-
-.. Note:: `Host` and `SNI` matchers can be used at the same time for the same domains, to route HTTP and TLS traffic to different sockets.
-.. Attention:: When Browsers find an available HTTPS socket for the same domain name, they might force a redirect to the secure channel. Verify with curl that the HTTP route indeed works as intended.
-
-
-SSH
----
-
-This is a raw protocol matcher. It will match **all** SSH traffic that the default ports of Caddy receive, and proxy it to the selected upstream. **Only one of these routes will match. Host Headers or SNI can not be evaluated.**
+This is a raw protocol matcher. It will match **all** traffic that looks like the chosen protocol on the default ports of Caddy, and proxy it to the selected upstream. **Only one of these routes per protocol will match. Host Headers or SNI can not be evaluated.**
 
 * Go to :menuselection:`Services --> Caddy Web Server --> Reverse Proxy --> Layer4 Routes`
 * Press **+** to create a new `Layer4 Route`
@@ -745,6 +736,17 @@ Options                             Values
 * Press **Save** and **Apply**
 
 Now an SSH client can open up a proxied connection like ``ssh app1.example.com -p 443`` and the SSH traffic will go over the same port as other HTTP/HTTPS traffic. Caddy becomes a protocol multiplexer.
+
+.. Tip:: If another route is added, e.g. with the RDP matcher, then SSH and RDP will be on the same port but will be proxied to different upstreams.
+
+
+HTTP (Host Header)
+------------------
+
+Same logic as the `SNI` matcher, but can be used to route `HTTP` traffic, since the `Host Header` is evaluated.
+
+.. Note:: `Host` and `SNI` matchers can be used at the same time for the same domains, to route HTTP and TLS traffic to different sockets.
+.. Attention:: When Browsers find an available HTTPS socket for the same domain name, they might force a redirect to the secure channel. Verify with curl that the HTTP route indeed works as intended.
 
 
 TLS (SNI)
@@ -814,6 +816,7 @@ Help, Nothing Works!
 
 .. Note:: Even though Caddy itself is quite easy to configure in the plugin, setting the infrastructure up for it to work correctly imposes the real challenge. If you feel stumped, the best approach is getting knowledge about what `should` happen. This section tries to explain that, and give examples how to resolve issues.
 .. Tip:: Most errors happen because the infrastructure is not set up correctly, or wrong options for the `HTTP Handler` have been set.
+.. Attention:: Do not use the Layer4 module without knowing the implications of it. It is for very advanced usecases. Better deactivate it if things do not work as expected.
 
 **This is what should happen if Caddy works correctly:**
 

--- a/source/manual/how-tos/caddy.rst
+++ b/source/manual/how-tos/caddy.rst
@@ -686,7 +686,7 @@ With these imports, the full potential of Caddy can be unlocked. The GUI options
 Caddy: Layer4 Routes
 ====================
 
-.. Attention:: Requires ``os-caddy-1.6.2`` or later. This is new feature of Caddy and in active developement. Consider this a feature preview. Even though it seems to work as expected, do not use this in production. The scope of features inside this plugin are very contained - so when something changes upstream, it can hopefully be downstreamed without huge effort or rewriting the whole logic.
+.. Attention:: Requires ``os-caddy-1.6.2`` or later. This is a new feature of Caddy and in active developement. Consider this a feature preview. Even though it works as expected, do not use this in production. The scope of Layer4 features inside this plugin are very contained - so when something changes upstream, it can be hopefully downstreamed without rewriting the whole logic.
 
 
 -------------
@@ -699,19 +699,28 @@ Enable Layer4
 
 .. Note:: Layer4 Routing can be disabled completely at any time by disabling the `(Feature Preview) Enable Layer4` checkbox.
 .. Tip::
-    **Layer4 Routing Precedence** (automatic, order of listed items does not matter)
+    **Layer4 Routing Precedence** (automatic, order of listed items in bootgrid does not matter)
 
-    1. `SNI`
-    2. `not SNI`
-    3. `HTTP Handlers` (hidden default Route)
+    #. `Host`
+    #. `SNI`
+    #. `not SNI`
+    #. `HTTP Handlers` (hidden default route)
 
 --------
 Matchers
 --------
 
-A matcher checks the first bytes of a TCP/UDP paket and decides which protocol it could be. Right now, only SNI matchers are supported. They check the contents of the `Client Hello` at the start of a TLS handshake. Since most traffic is TLS, there is a lot of flexibility without making configuration too complicated.
+A matcher checks the first bytes of a TCP/UDP paket and decides which protocol it could be. Right now, only SNI and Host matchers are supported. They either check the contents of the `Client Hello` at the start of a TLS handshake, or the `Host Header` in case of HTTP traffic. Since most traffic is TLS and HTTP, there is a lot of flexibility without making configuration too complicated.
 
-The domains do not have to exist in the tabs `Domains` or `Subdomains`. Layer4 Routes match before `Domains`. That is why already existing `Domains` can not be selected in a matcher. They have to be manually filled in. Multiple `Domains` and even wildcards be matched in the same Layer4 Route.
+`Layer4 Routes` match before domains in the `Domains Tab`. That is why already existing domains can not be selected in a matcher. They have to be manually filled in. Multiple domains and even wildcards can be matched in the same `Layer4 Route`.
+
+
+Host
+----
+
+Same logic as the `SNI` matcher, but can be used to route `HTTP` traffic, since the `Host Header` is evaluated.
+
+.. Note:: `Host` and `SNI` matchers can be used at the same time for the same domains, to route HTTP and TLS traffic to different sockets.
 
 
 SNI
@@ -738,6 +747,8 @@ Caddy listens on the default HTTP and HTTPS ports. All traffic it receives on th
 With the `Matcher SNI`, the `Client Hello` of the TLS traffic is analyzed. When the `Client Hello` includes `app1.example.com`, the traffic will be matched by the new `Layer4 Route`. The raw `TCP/UDP` traffic will be streamed to the chosen socket - which consists of `Upstream Domain` and `Upstream Port`.
 
 Any other traffic that is not matched by any `Layer4 Route` will be routed to the `HTTP Handlers`, where the configured `Domains` and `Subdomains` can receive and reverse proxy it.
+
+.. Note:: When `Auto HTTPS` is enabled, all clients will be permanently redirected to HTTPS automatically. If that should not happen, set it to `Disable Redirects`.
 
 
 not SNI

--- a/source/manual/reverse_proxy.rst
+++ b/source/manual/reverse_proxy.rst
@@ -16,15 +16,14 @@ as well as other checks to protect the application behind. Such checks are malwa
 spam, web attack detection and so on.
 
 .. Warning::
-    Reverse proxies support you to prevent common attacks to your
-    web application by bots but will never provide a 100% success rate in detection of
+    Reverse proxies could prevent common attacks to your
+    web application by bots but would never provide a 100% success rate when detecting
     bad traffic.
-    Especially a targeted attack will very likely be not detected because a lot of
+    Especially a targeted attack would very likely not be detected, because a lot of
     effort has been taken to prevent detection.
     Do not use a reverse proxy as a replacement / excuse for not fixing the main
     problems like known vulnerabilities in libraries, outdated software, or
-    vulnerabilities in your own code by updating / removing them or by changing
-    your own code.
+    vulnerabilities in your own code.
 
 
 Supported Reverse Proxies in OPNsense
@@ -34,7 +33,7 @@ Supported Reverse Proxies in OPNsense
 ftp-proxy Makes FTP work
 nginx     HTTP, TCP- and UDP streams
 HAProxy   HTTP and TCP streams
-Caddy     HTTP streams 
+Caddy     HTTP, TCP- and UDP streams
 postfix   SMTP (e-mail)
 relayd    TCP streams
 ========= ==========================
@@ -52,18 +51,18 @@ used in companies to scan traffic for malware. See the more specific pages
 
 A reverse proxy is software which takes a request or a connection from a client
 and sends it to an upstream server. It may change some data if needed (for
-exmaple inject HTTP header or perform access control). A reverse proxy can be
+example inject HTTP header or perform access control). A reverse proxy can be
 generic for any protocol, but is commonly used for HTTP(S).
 
-A reverse proxy does not need to by fully aware of data it is transferring it needs
-to know, which upstream is responsible to process it and some metadata to know
+A reverse proxy does not need to by fully aware of data it is transferring,
+it only needs to decide which upstream is responsible to process it and some metadata to know
 what it should do (like for caching a Cache-Control header and for
 authorizing an Authentication header in HTTP).
 
-A webserver, in contrast to a reverse proxy, finally processes the request
+A webserver - in contrast to a reverse proxy - processes the request
 (the webserver contains the business logic in the web application) and sends
 a response depending on the request, which may be modified or cached
-by a reverse (for example Varnish_, nginx_) or forward proxy
+by a reverse proxy (for example Varnish_, nginx_) or forward proxy
 (see :doc:`how-tos/proxyicapantivirus`, :doc:`how-tos/cachingproxy`).
 For example, a webserver serves a file called index.html from the local file
 system or processes an API endpoint and returns the result.
@@ -110,7 +109,7 @@ Apache HTTPd (with modules like mod_php)       Webserver with interpreter module
 **Upstream, Backend**
 
 A single or multiple servers which can be used for load balancing the client
-request to. All servers used in an upstream must act equally (same protocol
+requests. All servers used in an upstream must act equally (same protocol
 etc.) but do not need to run on the same port.
 
 **Upstream Server, Backend Server**
@@ -137,13 +136,11 @@ be disabled.
 TLS - Different ways to use it
 ==============================
 
-1) Breaking up the connection on the firewall (down- and upstream are using TLS)
+1. Breaking up the connection on the firewall (down- and upstream are using TLS)
 --------------------------------------------------------------------------------
 
 In this setup we do have two TLS protected connections. One from the client to
 the firewall, and one from the firewall to the backend.
-
-.. image::  images/sample_network_tls_broken_up.png
 
 The advantage of this setup is that you can use it to route based on paths or
 other properties and you can present another certificate to the client.
@@ -154,10 +151,8 @@ may be invalid (for example outdated). Please note that it is not recommended
 to disable certificate checks in the upstream but it may be required in some
 setups.
 
-2) Decrypt an encrypted upstream (downstream plain, upstream TLS protected)
+2. Decrypt an encrypted upstream (downstream plain, upstream TLS protected)
 ---------------------------------------------------------------------------
-
-.. image::  images/sample_network_tls_decrypt.png
 
 This setup may not make much sense in most cases. It may have the advantage
 if you have trouble with some software which does not allow a not encrypted
@@ -167,10 +162,8 @@ support it. If you need that, do not make it available via the internet
 because there is probably a reason that the upstream server is TLS only.
 
 
-3) TLS Offloading (downstream is TLS protected, upstream is plain)
+3. TLS Offloading (downstream is TLS protected, upstream is plain)
 ------------------------------------------------------------------
-
-.. image::  images/sample_network_tls_offload.png
 
 This setup should be preferred when it is supported. It has the advantage
 that it fully supports TLS for the client while it does not need a lot of
@@ -180,10 +173,8 @@ power to do a TLS handshake inside your own computer centre.
     You should not use this for upstream servers reachable via untrusted networks.
     Use (1) or (4) in such cases.
 
-(4) TLS Passthough
+4. TLS Passthough
 ------------------
-
-.. image::  images/sample_network_tls_pass_trough.png
 
 In this mode, the proxy will just pass though the connection and has no access
 to the encrypted payload. You cannot match on anything of the protocol itself.
@@ -204,23 +195,5 @@ better than plain NAT.
 Tutorials
 =========
 
-Basic Reverse Proxy Setup
--------------------------
 * :doc:`how-tos/nginx`
-* :doc:`how-tos/nginx_streams`
-* :doc:`how-tos/mailgateway`
-
-
-Setup Authentication
---------------------
-* :doc:`how-tos/nginx_basic_auth`
-* :doc:`how-tos/nginx_ip_acl`
-* :doc:`how-tos/nginx_tls_auth`
-
-Firewalling
------------
-* :doc:`how-tos/nginx_waf`
-
-Misc
-----
-* :doc:`how-tos/nginx_hosting`
+* :doc:`how-tos/caddy`


### PR DESCRIPTION
* reverse_proxy.rst: Remove pictures, fix a few typos, make it a bit more concise.

Removing the pictures is up for discussion. In my opinion they look really outdated and are in a stark contrast to the documentation. The files are not touched in this PR, just the links to them are removed.
 
* Update caddy.rst: Add Layer4 Routes section and fix some terminology.
For: https://github.com/opnsense/plugins/pull/4112
* Update caddy.rst: Add SSH protocol matcher to docs, adjust protocol matcher names
For: https://github.com/opnsense/plugins/pull/4133