### PR TITLE
Update drop.rst 

### DIFF
--- a/source/manual/how-tos/drop.rst
+++ b/source/manual/how-tos/drop.rst
@@ -82,7 +82,7 @@ Enter the following configuration and leave all other parameters on default valu
 =================== ================ =============================================
  **Action**          Block            *Choose block to drop the incoming traffic*
  **Interface**       WAN              *Should be the default value*
- **TCP/IP Version**  IPv4             *For our example we use IPv4*
+ **TCP/IP Version**  IPv6             *For our example we use IPv6*
  **Source**          spamhaus_dropv6  *Our alias for the DROP list*
  **Category**        Spamhaus         *Freely chosen Category*
  **Description**     Block DROPv6     *Freely chosen description*


### PR DESCRIPTION
Updated drop.rst → Forgot to change 1 line from the latest merge of Spamhaus EDROP list. #587

EDROPv6 changed from IPv4 to IPv6 in "_[Step 2 - Firewall Rules Inbound Traffic](https://docs.opnsense.org/manual/how-tos/drop.html#step-2-firewall-rules-inbound-traffic)_"

Sorry!
