### PR TITLE
docs: Fix typo in function name

### DIFF
--- a/source/development/backend/legacy.rst
+++ b/source/development/backend/legacy.rst
@@ -68,7 +68,7 @@ Configure
 The configure plugin can be used to catch certain events, such as :code:`bootup`, :code:`newwanip` and others.
 
 A small sample of a registration is shown below, which registers the functions :code:`myplugin_configure()` on bootup
-and :code:`myplugin_configure()_vpn` on vpn state change where the latter is accepting two (:2) parameters at most.
+and :code:`myplugin_configure_vpn()` on vpn state change where the latter is accepting two (:2) parameters at most.
 Note that the default number of arguments passed to the listeners is one (:1) which is the :code:`$verbose`  parameter
 steering whether the function is allowed to print progress or not.  The maximum number of arguments passed depends
 on the particular event provider.  For more details see below.


### PR DESCRIPTION
Minor documentation fix regarding a function name.