### PR TITLE
docs: drop header controller type

### DIFF
--- a/source/development/frontend/controller.rst
+++ b/source/development/frontend/controller.rst
@@ -94,7 +94,6 @@ readonly      if true, input fields will be readonly
 ==================  ===========================================================================================
 Name                Description
 ==================  ===========================================================================================
-header              Header row
 text                Single line of text
 password            Password field for sensitive input. The contents will not be displayed.
 textbox             Multiline text box


### PR DESCRIPTION
`header` listed in table from [User forms types](https://docs.opnsense.org/development/frontend/controller.html#user-forms) is not present in code. Maybe it should be dropped from the doc :shrug: 

https://github.com/opnsense/core/blob/master/src/opnsense/mvc/app/views/layout_partials/form_input_tr.volt#L31-L39

---

BTW is there a way to define our own `layout_partials/custom_form.volt` inheriting `layout_partials/base_form.volt` inside a custom plugin? I would be interested by adding a "bootstrap alert" in the **middle** of an automatically generated form. Thanks

EDIT: ok half part of what I was trying. But as such the inheritence don't permit to add custom type in the middle of the form.

`index.volt`
```
{{ partial("kumy/sample/layout_partials/custom_form",['fields':formAdvancedSettings,'id':'frm_AdvancedSettings']) }}
```

`/usr/local/opnsense/mvc/view/kumy/sample/layout_partials/custom_form.volt`
```
{% extends 'layout_partials/base_form.volt' %}
[…]
```