### PR TITLE
Update legacy.rst

### DIFF
--- a/source/development/backend/legacy.rst
+++ b/source/development/backend/legacy.rst
@@ -289,12 +289,14 @@ To test if a service registration functions properly, just restart the syslog fa
 
 .. Note::
 
-    In order to define local targets for Syslog-NG you can just add **local** filters which will be collected into
+    In order to define local targets for Syslog-NG you can just add **local** filters (e.g. by creating 
+    :code:`src/opnsense/service/templates/OPNsense/Syslog/local/helloworld.conf`) which will be collected into
     one large syslog configuration.
     The readme on `GitHub <https://github.com/opnsense/core/blob/master/src/opnsense/service/templates/OPNsense/Syslog/local/README>`__
     describes the process.
     When running into issues, always make sure to manually restart syslog-ng first (:code:`service syslog-ng restart`), definition errors won't
-    be written into any log.
+    be written into any log. You might also have to restart the plugin (:code:`pluginctl -s syslog-ng restart`) for the syslog-ng configuration
+    files to be regenerated.
 
 .. Note::
 

--- a/source/development/backend/legacy.rst
+++ b/source/development/backend/legacy.rst
@@ -295,7 +295,7 @@ To test if a service registration functions properly, just restart the syslog fa
     The readme on `GitHub <https://github.com/opnsense/core/blob/master/src/opnsense/service/templates/OPNsense/Syslog/local/README>`__
     describes the process.
     When running into issues, always make sure to manually restart syslog-ng first (:code:`service syslog-ng restart`), definition errors won't
-    be written into any log. You might also have to restart the plugin (:code:`pluginctl -s syslog-ng restart`) for the syslog-ng configuration
+    be written into any log. You will also have to restart the plugin (:code:`pluginctl -s syslog-ng restart`) for the syslog-ng configuration
     files to be regenerated.
 
 .. Note::


### PR DESCRIPTION
I found the syslog-ng Note confusing/misleading, especially in its proximity to syslog. Particularly since I wasn't aware of the difference. (After a few days of headscratching,) It became obvious that I 'just' need to locate syslog-ng config.

I was going to open an issue, but a PR is easier to point to the exact file location. Perhaps somebody more experienced would instead prefer to write a Syslog-NG section instead.