### PR TITLE
Fix typos in ipsec-swanctl-rw-ikev2-eap-mschapv2.rst

### DIFF
--- a/source/manual/how-tos/ipsec-swanctl-rw-ikev2-eap-mschapv2.rst
+++ b/source/manual/how-tos/ipsec-swanctl-rw-ikev2-eap-mschapv2.rst
@@ -93,7 +93,7 @@ Create a server certificate for your IPsec VPN. The lifetime of the certificate 
     **Certificate authority:**                      IPsec CA
     **Type:**                                       Server Certificate
     **Key Type:**                                   RSA
-    **Key lenght (bits):**                          2048
+    **Key length (bits):**                          2048
     **Digest Algorithm:**                           SHA256
     **Lifetime (days):**                            365
     **Country Code:**                               Enter your Country Code
@@ -645,7 +645,7 @@ For full control over DNS, you should either use Unbound on the OPNsense or the 
 
 **Enable** Unbound and leave the *Network Interfaces* on *All (recommended)*. Next go to *Query Forwarding* and input your *Custom forwarding* servers. For example your Samba or Microsoft Active Directory Domain Controllers.
 
-Unbound listens on port 53 UDP/TCP on all network interfaces of the Opnsense. If you followed all prior steps, access to your LAN is already permitted from the IPsec Network. You can use the IP addresses of the OPNsense in that network as target for the DNS queries.
+Unbound listens on port 53 UDP/TCP on all network interfaces of the OPNsense. If you followed all prior steps, access to your LAN is already permitted from the IPsec Network. You can use the IP addresses of the OPNsense in that network as target for the DNS queries.
 
 In this example they are: ``192.168.1.1`` and ``2001:db8:1234:1::1``.
 


### PR DESCRIPTION
Fixes typos in `source/manual/how-tos/ipsec-swanctl-rw-ikev2-eap-mschapv2.rst`

A typo in length, and case of OPNsense.