### PR TITLE
manual: user must 'Apply' changes after generating wg peer

### DIFF
--- a/source/manual/how-tos/wireguard-client.rst
+++ b/source/manual/how-tos/wireguard-client.rst
@@ -59,11 +59,11 @@ Step 2 - Configure the client peer
      **Allowed IPs**        *Unique tunnel IP address (IPv4 and/or IPv6) of client - it should be a /32 or /128 (as applicable) within the subnet configured on the WireGuard Instance. For example, 10.10.10.2/32*
     ====================== ====================================================================================================
 
-- **Save** the Peer configuration, and then click **Save** again
+- **Save** the Peer configuration, and then click **Apply**
 - Now go back to :menuselection:`VPN --> WireGuard --> Instances`
 - Open the Instance configuration that was created in Step 1 (eg :code:`HomeWireGuard`)
 - In the Peers dropdown, select the newly created Peer (eg :code:`Phone`)
-- **Save** the Instance configuration again, and then click **Save** once more
+- **Save** the Instance configuration again, and then click **Apply**
 - Repeat this Step 2 for as many clients as you wish to configure
 
 ----------------------------------

--- a/source/manual/vpnet.rst
+++ b/source/manual/vpnet.rst
@@ -746,7 +746,7 @@ Each newly created client will receive a keypair, for which the public key will 
 After providing the relevant information for the client to login, you can copy the qrcode or the text in the :code:`Config`
 text box to configure the client.
 
-Don't forget to press the "Store and generate next" button to actually store the public information in the firewall so the client
+Don't forget to press the "Store and generate next" button to actually store the public information in the firewall and click "Apply" on the "Peers" page so the client
 is able to login.
 
 


### PR DESCRIPTION
After clicking "Store and generate next," `wg showconf wg1` on opnsense doesn't show the new peer (and connection attempts from the peer fail without explanation). Visiting the WG->Peers page and clicking "Apply" fixes this.

I think it'd be better for "Store and generate next" to automatically apply the new peer to the wg config, but until that's the case, at least the docs can describe a procedure to make it work.