### PR TITLE
Update hardware.rst

### DIFF
--- a/source/manual/hardware.rst
+++ b/source/manual/hardware.rst
@@ -119,7 +119,7 @@ have massive impact on it. The candidates are:
 `State transition tables <https://en.wikipedia.org/wiki/State_transition_table>`__
     it is a known fact, that each state table entry requires about 1 kB
     (kilobytes) of RAM. The average state table, filled with 1000
-    entries will occupy about ~10 MB (megabytes) of
+    entries will occupy about ~1 MB (megabytes) of
     `RAM <https://en.wikipedia.org/wiki/Random-access_memory>`__.
     OPNsense usage settings with hundred of thousands of connections
     will require memory accordingly.


### PR DESCRIPTION
There is a mistake in state transition table calculation. The documention says : 
"1 table entry require 1kB, so 1000 entry require 10MB." But 1000*1kB = 1000kB = 1MB.