### PR TITLE
ipsec roadwarrior: add always send certificate to support native ios client

### DIFF
--- a/source/manual/how-tos/ipsec-swanctl-rw-ikev2-eap-mschapv2.rst
+++ b/source/manual/how-tos/ipsec-swanctl-rw-ikev2-eap-mschapv2.rst
@@ -208,6 +208,7 @@ Create EAP Pre-Shared Keys. The local identifier is the username, and the Pre-Sh
     **Rekey time:**                                 2400
     **DPD delay:**                                  30
     **Pools:**                                      ``pool-roadwarrior-ipv4`` ``pool-roadwarrior-ipv6``
+    **Send certificate:**                           Always
     **Keyingtries:**                                0
     **Description:**                                roadwarrior-eap-mschapv2-p1
     ==============================================  ====================================================================================================


### PR DESCRIPTION
## What
I've added a single line, setting the Send Certificate behavior to "Always".

## Why
Part of https://github.com/opnsense/docs/issues/639

We also stumbled about the Apple iOS related problem after following the current documentation, so I decided to improve it.

## Impact prognosis
Since the how-to sets up the authentication of the OPNSense side with a certificate, the certificate needs to be sent to the client during authentication. This change fixes the behavior for clients that don't request the cert without changing behavior for clients that already did request the cert.