### PR TITLE
Wireguard roadwarrior : Add tip to use peer generator and clarify DNS when using Unbound

### DIFF
--- a/source/manual/how-tos/wireguard-client.rst
+++ b/source/manual/how-tos/wireguard-client.rst
@@ -50,7 +50,7 @@ Step 2 - Configure the client peer
 
 .. Tip::
 
-    Peers can be generated using the new peer generator feature under :menuselection:`VPN --> WireGuard --> Peer generator`. If using the peer generator and Unbound DNS, fill the DNS server with the tunnel address (eg* :code:`10.10.10.1` *).
+    Peers can be generated using the new peer generator feature under :menuselection:`VPN --> WireGuard --> Peer generator`. If using the peer generator and require Unbound DNS to serve names, fill the DNS server with the tunnel address (eg* :code:`10.10.10.1` *).
 
 - Go to :menuselection:`VPN --> WireGuard --> Peers`
 - Click **+** to add a new Peer

--- a/source/manual/how-tos/wireguard-client.rst
+++ b/source/manual/how-tos/wireguard-client.rst
@@ -48,6 +48,10 @@ Step 1 - Configure the Wireguard Instance
 Step 2 - Configure the client peer
 ---------------------------------------------
 
+.. Tip::
+
+    Peers can be generated using the new peer generator feature under :menuselection:`VPN --> WireGuard --> Peer generator`. If using the peer generator and Unbound DNS, fill the DNS server with the tunnel address (eg* :code:`10.10.10.1` *).
+
 - Go to :menuselection:`VPN --> WireGuard --> Peers`
 - Click **+** to add a new Peer
 - Configure the Peer as follows (if an option is not mentioned below, leave it as the default):

--- a/source/manual/how-tos/wireguard-client.rst
+++ b/source/manual/how-tos/wireguard-client.rst
@@ -269,7 +269,7 @@ Client configuration is largely beyond the scope of this how-to since there is s
      **[Interface]**
      **Address**            *Refers to the IP(s) specified as Allowed IPs in the Peer configuration on OPNsense. For example, 10.10.10.2/32*
      **PrivateKey**         *Refers to the private key that (along with a public key) needs to be manually or automatically generated on the client. The corresponding public key must then be copied into the Peer configuration on OPNsense for the relevant client peer - see Step 2*
-     **DNS**                *Refers to the DNS servers that the client should use for the tunnel - see note below*
+     **DNS**                *Refers to the DNS servers that the client should use for the tunnel (see note below). For example, 10.10.10.1*
 
      **[Peer]**
      **PublicKey**          *Refers to the public key that is generated on OPNsense. Copy the public key from the Instance configuration on OPNsense - see Step 1*


### PR DESCRIPTION
Wireguard roadwarrior : Add tip to use peer generator and clarify DNS when using Unbound. The current tuto doesn't mention the peer generator feature. I think the right way would be to rewrite section 2 entirely to leverage the peer generator feature and explain to use the QR code before saving it, but at least with the tip people will know they can use it (and configuration is pretty much the same).

Also, client config needs the DNS to be the tunnel address for it to work.

=====
For context, I've been trying to setup VPN for the past few days. I gave up on IPSec and tried Wireguard next. Followed the how-to step by step a few times and never could get it to work, until I found that I simply needed to configure the DNS on the client side to be the address of the tunnel (10.10.10.1 in the tuto example).