### PR TITLE
Fixed typo: gatew -> gateway

### DIFF
--- a/source/manual/multiwan.rst
+++ b/source/manual/multiwan.rst
@@ -31,7 +31,7 @@ The technology used to offer multiwan is called "policy based routing" or "sourc
 Terminology
 ------------------------
 
-When configuring gatew groups, there is a limited number of options and terms being used. Besides the name
+When configuring gateway groups, there is a limited number of options and terms being used. Besides the name
 of the group, one can find the following terms on the page:
 
 =====================================================================================================================


### PR DESCRIPTION
Hey,

First of all, thanks a lot for the documentation!
I think there was a small typo on the gateway groups page (`multiwan.rst`)

`gatew` -> `gateway`


All the best!