### PR TITLE
Adding the active optical cable section and a tested AOC to the HCL

### DIFF
--- a/source/hardware/sfp_compatibility.rst
+++ b/source/hardware/sfp_compatibility.rst
@@ -50,9 +50,14 @@ needed to use SMF is often more expensive in comparison to MMF.
 Multi-mode fiber is the alternative for SMF (up to 550M for 10Gb/s), often used for backbone applications in
 buildings and usually connected with OM3 Duplex-LC patch cords.
 
-- Direct-Attach (DAC)
+- Direct-Attach Copper (DAC)
 
 For short ranges (up to 10M), often a popular choice due to low cost and low latency.
+
+- Active Optical Cable (AOC)
+
+An alternative to DAC with lower latency, longer reach, electromagnetic interference (EMI) immunity and smaller,
+more manageable cable. An economical option compared to using MMF patch cable and network interface modules.
 
 .. attention::
 
@@ -178,6 +183,17 @@ Netgear    AXC761                         10G
 Startech   DACSFP10G1M                    10G
 Ubiquiti   UniFi 1m DAC                   10G
 ========== ============================== ============= =========================
+
+--------------------------------------
+10G Active Optical Cable
+--------------------------------------
+
+============= ============================== ============= =========================
+Vendor        Type                           Speed         Notes
+============= ============================== ============= =========================
+Cisco-Finisar SFP-10G-AOC3M                  10G
+============= ============================== ============= =========================
+
 
 **ICE**
 =====================================================================================================================


### PR DESCRIPTION
Using the Cisco (Finisar) `SFP-10G-AOC3M` active optical cable (AOC) in the DEC2752 without any issues.  Version 24.7.12  detected the AOC as:

```
ax0: SFP detected:
ax0:   vendor:   CISCO-FINISAR
ax0:   part number:    FCBG110SD1C03-CS
ax0:   revision level: A
ax0:   serial number:  <--redacted-->
ax0: Link is UP - 10Gbps/Full - flow control off
```
