### PR TITLE
Type-hint ApiParser using TypedDict

### DIFF
--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -1,8 +1,29 @@
 import os
 import re
-from lib.phply.phpast import Class,  MethodCall, Constant, UnaryOp
+from typing import List, Literal, NotRequired, TypedDict
+from lib.phply.phpast import Class, MethodCall, Constant, UnaryOp
 from lib.phply.phplex import lexer
 from lib.phply.phpparse import make_parser
+
+
+HttpMethod = Literal["GET", "POST", "GET,POST"]
+ControllerType = Literal["Abstract [non-callable]", "Service", "Resources"]
+
+class ApiAction(TypedDict):
+    command: str
+    parameters: str
+    method: HttpMethod
+    model_path: NotRequired[str]
+
+class ApiController(TypedDict):
+    actions: List[ApiAction]
+    type: ControllerType
+    module: str
+    controller: str
+    is_abstract: bool
+    base_class: str | None
+    filename: str
+    model_filename: str | None
 
 
 DEFAULT_BASE_METHODS = {
@@ -122,7 +143,7 @@ class ApiParser:
                 print("ignoring token %s at line %s" % (p.value, p.lexer.lineno))
             self.parser.errok()
 
-    def parse_api_php(self):
+    def parse_api_php(self) -> ApiController:
         """ collect api endpoints
         """
         self.api_commands = {}


### PR DESCRIPTION
Hi, I'm looking to build on this code and I would personally find type-hints helpful. Feel free to reject if you don't want them. In that case, I'll remove from my own branch before any future PR.

The problem to be solved: when consuming the library, a developer must manually track the expected keys to avoid KeyError. With type hints, the IDE can auto-complete the correct keys and hint the values.

As you probably know, TypedDict is a check-time construct and has no runtime effect.

My personal preference is to use pydantic, as the syntax is cleaner, but it would add a dependency and has a runtime effect. If you'd like me to resubmit using pydantic, let me know, and I'll update and test.