### PR TITLE
Type-hint ApiParser using pydantic

### DIFF
--- a/collect_api_endpoints.py
+++ b/collect_api_endpoints.py
@@ -59,22 +59,22 @@ if __name__ == '__main__':
         }
         for controller in all_modules[module_name]:
             payload = {
-                'type': controller['type'],
-                'module': controller['module'],
-                'controller': controller['controller'],
-                'filename': controller['filename'],
-                'is_abstract': controller['is_abstract'],
-                'base_class': controller['base_class'],
+                'type': controller.type,
+                'module': controller.module,
+                'controller': controller.controller,
+                'filename': controller.filename,
+                'is_abstract': controller.is_abstract,
+                'base_class': controller.base_class,
                 'endpoints': [],
                 'uses': []
             }
-            for endpoint in controller['actions']:
-                payload['endpoints'].append(endpoint)
-            if controller['model_filename']:
+            for endpoint in controller.actions:
+                payload['endpoints'].append(endpoint.model_dump())
+            if controller.model_filename:
                 payload['uses'].append({
                     'type': 'model',
-                    'link': source_url(cmd_args.repo, controller['model_filename']),
-                    'name': os.path.basename(controller['model_filename'])
+                    'link': source_url(cmd_args.repo, controller.model_filename),
+                    'name': os.path.basename(controller.model_filename)
                 })
             template_data['controllers'].append(payload)
 

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -1,9 +1,9 @@
 import os
-from . import ApiParser
+from . import ApiParser, Controller
 
 EXCLUDE_CONTROLLERS = ['Core/Api/FirmwareController.php']
 
-def collect_api_modules(source: str, debug: bool = False) -> dict[str, list[dict]]:
+def collect_api_modules(source: str, debug: bool = False) -> dict[str, list[Controller]]:
     # collect all endpoints
     all_modules = dict()
     for root, dirs, files in os.walk(source):
@@ -16,10 +16,9 @@ def collect_api_modules(source: str, debug: bool = False) -> dict[str, list[dict
                     break
             if not skip and filename.lower().endswith('controller.php') and filename.find('mvc/app/controllers') > -1 \
                     and root.endswith('Api'):
-                payload = ApiParser(filename, debug).parse_api_php()
-                if len(payload) > 0:
-                    if payload['module'] not in all_modules:
-                        all_modules[payload['module']] = list()
-                    all_modules[payload['module']].append(payload)
+                controller = ApiParser(filename, debug).parse_api_php()
+                if controller.module not in all_modules:
+                    all_modules[controller.module] = list()
+                all_modules[controller.module].append(controller)
 
     return all_modules

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ sphinxcontrib-actdiag
 blockdiagcontrib-cisco
 Pillow
 ply
+pydantic>=2.0.0


### PR DESCRIPTION
Alternative approach using pydantic instead of TypedDict. It's a larger delta, but dot-syntax is nicer than `['key']` IMO.

I have verified that there's no diff in .rst output from collect_api_endpoints compared to master.

For awareness, each instantiation performs validation, so runtime errors may occur that would otherwise slip into Jinja and perhaps not cause an issue. IMO, this is an advantage.

Duplicate of #709 

Closes #709 