### PR TITLE
www/caddy: change certificate to Auto HTTPS

### DIFF
--- a/source/manual/how-tos/caddy.rst
+++ b/source/manual/how-tos/caddy.rst
@@ -103,7 +103,7 @@ Options                        Values
 **Protocol:**                  ``https://``
 **Domain:**                    ``foo.example.com``
 **Port:**                      `Leave empty`
-**Certificate:**               ``ACME (HTTP-01, TLS-ALPN-01)``
+**Certificate:**               ``Auto HTTPS``
 ============================== =====================================================================
 
 * | Press **Save**


### PR DESCRIPTION
This was changed a while ago. Somebody on reddit noticed.