### PR TITLE
virtuals: update/add plugin install and fix checksum offloading instructions

### DIFF
--- a/source/manual/virtuals.rst
+++ b/source/manual/virtuals.rst
@@ -140,7 +140,7 @@ This issue can be caused by a defective drive. Changing the drive mode to IDE ha
 been reported to help for certain ESXi versions.
 
 
-NAT issues on XenServer/XCP-NG
+NAT / performance issues on XenServer/XCP-NG
 -----------------------------------------
 This issue has been reported to be solved by disabling TX checksum offloading on Vifs (only there, not also in OPNsense DomU) - for details see this `documentation <https://docs.xcp-ng.org/guides/pfsense/#3-disable-tx-checksum-offload>`__.
 


### PR DESCRIPTION
Hello,

as plugins for tools/additions/agent for virtualization others, than vmware are in tier 3 (community), thus not shown in list by default, modified instructions for xen (and also added instructions for other virtualisation plugins) to make it easier for others to find them.

Also edited checksum offloading settings instructions for xen, according warning in XCP-NG [documentation](https://docs.xcp-ng.org/guides/pfsense/#3-disable-tx-checksum-offload).

Thanks :-)