### PR TITLE
wireguard-client-mullvad: clarifications, wording, and formatting

### DIFF
--- a/source/manual/how-tos/wireguard-client-mullvad.rst
+++ b/source/manual/how-tos/wireguard-client-mullvad.rst
@@ -14,15 +14,15 @@ you have read the basic howto :doc:`wireguard-client`.
 Step 1 - Setup WireGuard Instance
 ----------------------------------
 
-Go to the **Instances** tab and create a new instance. Give it a **Name** and set a desired **Listen Port**.
-If you have more than one server instance be aware that you can use the **Listen Port** only once. In 
-the field **Tunnel Address** insert an unsused private IP address and subnet mask. We don't need it in
+Go to the **Instances** tab and create a new instance. Give it a **Name** and set a desired **Listen port**.
+If you have more than one server instance be aware the **Listen port** must be unique for each instance. In
+the field **Tunnel address** insert an unused private IP address and subnet mask. We don't need it in
 the first step, but it will be required later. Every other field can be left blank.
 
-Hit **Save** and open your instance again to write down your public key. You will need it to get the rest
+Click **Save** and open your instance again to get your public key. You will need it to get the rest
 of the configuration from the Mullvad API servers.
 
-Now change to your OPNsense CLI via SSH or Console and execute *either* of the curl strings below. Please replace
+Now open the OPNsense CLI via SSH or the console and execute *either* of the curl commands below. Please replace
 **YOURACCOUNTNUMBER** with your own ID you got from MullvadVPN and **YOURPUBLICKEY** with the one in your **Instances**
 
 The command below is for Mullvad's standard API. DNS requests through a tunnel that uses tunnel IPs generated via this API are "hijacked", so that Mullvad's DNS servers are used to avoid leaks:
@@ -37,32 +37,42 @@ The alternative command below is for Mullvad's other API. DNS requests through t
 
 	curl -sSL https://api.mullvad.net/app/v1/wireguard-keys -H "Content-Type: application/json" -H "Authorization: Token YOURACCOUNTNUMBER" -d '{"pubkey":"YOURPUBLICKEY"}'
     
-What you receive is what WireGuard calls **Allowed IP** for your WireGuard Instance. Edit your instance again and remove
-the value of **Tunnel Address** that you used when setting it up and change it to the one received from the command above.
+The response is the **Allowed IP** for your WireGuard Instance. Edit your instance again and remove
+the value of **Tunnel address** that you used when setting it up and change it to the one received from the command above.
+
+--------------------------------
+Step 2 - Setup WireGuard Peer
+--------------------------------
 
 In the **Peers** tab, create a new Peer and give it a **Name**, then set 0.0.0.0/0 in **Allowed IPs**.
 
-Now go to Mullvad's server list_, set the filter to only `Wireguard` instances, and choose the one you like to use as your breakout. Write down it's
-public key and set it as **Public Key**.
+Now go to Mullvad's server list_, set the filter to only `WireGuard` instances, and choose the one you like to use as your breakout. Set the server's public key and as **Public key**.
 
-Also do not forget **Endpoint Address** and **Endpoint Port**. The **Endpoint Port** is 51820. The **Endpoint Address** will depend on which Mullvad server you wish to use. For example, if you want to use the "nl1-wireguard" server, the **Endpoint Address** will be :code:`nl1-wireguard.mullvad.net`.
+Set **Endpoint address** with the "Domain name" value in the server list and **Endpoint port** to 51820, WireGuard's default listening port.
+As an example: for the "nl1-wireguard" server, the **Endpoint Address** will be :code:`nl1-wireguard.mullvad.net`.
+In the **Instances** dropdown, select the instance created previously and click **Save**.
 
 .. _list: https://www.mullvad.net/en/servers/
 
-Go back to tab **Instances**, open the instance and choose the newly created peer in **Peers**.
-
-Now we can **Enable** the VPN in tab **General** and continue with the setup.
+Now we **Enable** WireGuard in the **General** tab and continue with the setup.
 
 --------------------------------
-Step 2 - Assignments and Routing
+Step 3 - Configure NAT
 --------------------------------
 
-To let your internal clients go through the tunnel, you must add a NAT entry. Go to 
-:menuselection:`Firewall --> NAT --> Outbound` and add a rule. Check that rule generation is set to manual
-or hybrid. Add a rule and select Wireguard as **Interface**. **Source** should be your
-LAN network and set **Translation / target** to **interface address**.
+To allow your internal clients through the tunnel, you must add a NAT entry. Go to 
+:menuselection:`Firewall --> NAT --> Outbound`, ensure that rule generation is set to either manual
+or hybrid. Add a new rule and select WireGuard as **Interface**. Set **Source** to your
+LAN network and **Translation / target** to **Interface address**.
 
 When assigning interfaces we can also add gateways to them. This would offer you the chance to 
 balance traffic via different VPN providers or do more complex routing scenarios.
 
 See the how-to on selective routing for further information :doc:`wireguard-selective-routing`
+
+--------------------------------
+Step 4 - Conclusion
+--------------------------------
+
+At this point, you should have a working connection and be able to pass the Mullvad connection test found on their website.
+If your configuration does not work or does not pass, a good place to start investigating is `VPN --> WireGuard --> Log file`.


### PR DESCRIPTION
Hi! I ended up needing to run through this guide, so I thought I'd do an editing pass while following it to clarify parts I found confusing.

Notable content changes:
- Guide steps
  - Split WireGuard peer setup into its own step
  - `Assignments and Routing` -> `Configure NAT` (more descriptive/specific)
  - Add conclusion step
 - Step 1
   - `curl strings` -> `curl commands`
- Step 2
  - Clarify where `51820` port number comes from (WireGuard default)
  - Clarify that "Domain name" from Mullvad's server list is used for `Endpoint address`
  - Remove going back to instance tab to map instance <-> peer, as already-open peer dialog has a dropdown for this
  - "Now we can **Enable** the VPN" -> "Now we **Enable** the VPN" (make it clear the user is supposed to do it here)
- Step 3
  - Remove duplicate "add a rule", mention rule generation must be manual/hybrid BEFORE adding a rule

Notable formatting changes:
- Make capitalization of buttons match web gui
- Consistent WireGuard capitalization