### PR TITLE
update consistent usage of the word instead

### DIFF
--- a/source/manual/diagnostics_interfaces.rst
+++ b/source/manual/diagnostics_interfaces.rst
@@ -114,7 +114,7 @@ It has some options you can choose from, which are detailed below.
 
 =========================== ==================================================================================================================
 Interface                   List of interfaces to start a capture on. A tcpdump process is started on each selected interface
-Promiscuous                 When set, the system will capture all traffic present on the interface in stead
+Promiscuous                 When set, the system will capture all traffic present on the interface instead
                             of the traffic heading to the firewall.
 Address Family              Capture IPv4, IPv6 or both
 Invert Protocol             Select all but the protocol selected below

--- a/source/manual/ips.rst
+++ b/source/manual/ips.rst
@@ -133,7 +133,7 @@ Some less frequently used options are hidden under the "advanced" toggle.
 Home networks                         Define custom home networks, when different than an RFC1918 network.
                                       In some cases, people tend to enable IDPS on a wan interface behind NAT
                                       (Network Address Translation), in which case Suricata would only see
-                                      translated addresses in stead of internal ones. Using this option, you can
+                                      translated addresses instead of internal ones. Using this option, you can
                                       define which addresses Suricata should consider local.
 default packet size                   With this option, you can set the size of the packets on your network.
                                       It is possible that bigger packets have to be processed sometimes.

--- a/source/manual/opnproxy.rst
+++ b/source/manual/opnproxy.rst
@@ -76,7 +76,7 @@ It is possible to use the proxy in transparant mode, but there are some constrai
 This paragraph tries to explain them one by one.
 
 * Using "Log SNI information only" is not supported in a useful way. As the browser is not aware of the proxy, it will request
-  access to an ip address in stead of a hostname. With full intercept mode, this is not really an issue as the next request will
+  access to an ip address instead of a hostname. With full intercept mode, this is not really an issue as the next request will
   be the actual question and does contain the hostname, but without interception, you can only filter on ip address which is often not very useful.
 * The client has to trust the CA which the proxy uses to automatically create certificates, which means all TLS requests will be signed by the firewall instead of the
   actual trustee.


### PR DESCRIPTION
First time contributor! 

- I noticed a few spots that could be updated to the more appropriate usage of the word `instead` vs. `in stead`
- `instead` used 200+ times across various docs already