### PR TITLE
docs: fix typos + grammar issues

### DIFF
--- a/source/manual/aliases.rst
+++ b/source/manual/aliases.rst
@@ -266,7 +266,7 @@ Below you will find a detailed specification our software can detect and process
 
     .. tab:: zip format (MaxMind)
 
-        This format requires a [zip] file containing the the following csv files:
+        This format requires a [zip] file containing the following csv files:
 
         .. list-table:: Title
            :widths: 50 25 25 25

--- a/source/manual/firewall_settings.rst
+++ b/source/manual/firewall_settings.rst
@@ -223,7 +223,7 @@ Enable syncookies
 This option is quite similar to the `syncookies <https://www.freebsd.org/cgi/man.cgi?syncookies>`__ kernel setting,
 preventing memory allocation for local services before a proper handshake is made.
 
-In this case pf will be protected agains state table exhaustion.
+In this case pf will be protected against state table exhaustion.
 
 The following modes are available:
 

--- a/source/manual/how-tos/caddy.rst
+++ b/source/manual/how-tos/caddy.rst
@@ -858,7 +858,7 @@ FAQ
 * | When using Caddy with IPv6, the best choice is to have a GUA (Global Unicast Address) on the WAN interface, since otherwise the TLS-ALPN-01 challenge might fail.
 * | `Let's Encrypt` or `ZeroSSL` can not be explicitly chosen. Caddy automatically issues one of these options, determined by speed and availability. These certificates can be found in ``/var/db/caddy/data/caddy/certificates``.
 * | When an `Upstream Destination` only supports TLS connections, yet does not offer a valid certificate, enable ``TLS Insecure Skip Verify`` in a `Handler` to mitigate connection problems.
-* | Caddy upgrades all connections automatically from HTTP to HTTPS. When cookies do not have have the ``secure`` flag set by the application serving them, they can still be transmitted unencrypted before the connection is upgraded. If these cookies contain very sensitive information, it might be a good choice to close port 80.
+* | Caddy upgrades all connections automatically from HTTP to HTTPS. When cookies do not have the ``secure`` flag set by the application serving them, they can still be transmitted unencrypted before the connection is upgraded. If these cookies contain very sensitive information, it might be a good choice to close port 80.
 * | There is optional Layer4 TCP/UDP routing support. In the scope of this plugin, only traffic that looks like TLS and has SNI can be routed. The `HTTP App` and `Layer4 App` can work together at the same time.
 * | There is no WAF (Web Application Firewall) support in this plugin. For a business grade Reverse Proxy with WAF functionality, use ``os-OPNWAF``.
 

--- a/source/manual/how-tos/carp.rst
+++ b/source/manual/how-tos/carp.rst
@@ -177,7 +177,7 @@ And another using the following:
 +-------------------------+------------------------------------+
 
 .. Note::
-    Always create Carp VIPs with the same subnet mask as it's parent interface. If the parent interface
+    Always create Carp VIPs with the same subnet mask as its parent interface. If the parent interface
     is ``/24``, your Carp VIP should also be ``/24``. Even though some sources claim that ``/32`` will work,
     services like DHCP Failover will fail with ``peer holds all free leases``.
 

--- a/source/manual/how-tos/drop.rst
+++ b/source/manual/how-tos/drop.rst
@@ -98,7 +98,7 @@ Enter the following configuration and leave all other parameters on default valu
 Step 3 - Firewall Rules Outbound Traffic
 ----------------------------------------
 
-Now do the same for outbound traffic traffic on the LAN interface.
+Now do the same for outbound traffic on the LAN interface.
 Go to :menuselection:`Firewall --> Rules` Select the **LAN** tab and press the **+** icon in the
 lower right corner.
 

--- a/source/manual/how-tos/dynamic_routing_bfd.rst
+++ b/source/manual/how-tos/dynamic_routing_bfd.rst
@@ -190,6 +190,6 @@ Verify the setup
 
 Go to :menuselection:`Routing --> Diagnostics --> BFD` and look at the Summary tab to view the status of the BFD neighbors.
 
-The real benefit of BFD can only be seen if there are multiple routes with different cost. When the BFD packets are interrupted, the route will quickly be discarted and the next best route will be installed and chosen. This will happen in just a ping or even faster.
+The real benefit of BFD can only be seen if there are multiple routes with different cost. When the BFD packets are interrupted, the route will quickly be discarded and the next best route will be installed and chosen. This will happen in just a ping or even faster.
 
 An example for a setup that will benefit from BFD is `IPsec Failover with VTI and OSPF </manual/how-tos/dynamic_routing_ospf.html#ipsec-failover-with-vti-and-ospf>`_

--- a/source/manual/how-tos/dynamic_routing_bgp.rst
+++ b/source/manual/how-tos/dynamic_routing_bgp.rst
@@ -313,7 +313,7 @@ They are your only upstream provider and will push a default route; you will not
 
 Your main task is configuring your neighbor correctly, employing a prefix list so that none of your local RFC1918 routes leak to the provider, and the provider can only
 announce the default route to you. If unsure, ask your provider what they expect from you as neighbor. Be mindful of a correct configuration, since an invalid one could get your neighbor
-temporarly disabled by the ISP.
+temporarily disabled by the ISP.
 
 .. Attention::
 

--- a/source/manual/how-tos/ipsec-s2s-route.rst
+++ b/source/manual/how-tos/ipsec-s2s-route.rst
@@ -4,7 +4,7 @@ IPsec VTI - Route based setup
 
 Most Site-to-Site VPNs are policy-based, which means you define a local and a remote
 network (or group of networks). Only traffic matching the defined policy is pushed into the
-VPN tunnel. As the demands for more complex and fault tolerant VPN scenarios growed over the
+VPN tunnel. As the demands for more complex and fault tolerant VPN scenarios have grown over the
 years, most major router vendors implemented a kind of VPN, the route-based IPSec.
 
 The difference is that local and remote network is just 0.0.0.0/0, so anything can travel

--- a/source/manual/how-tos/ipsec-s2s.rst
+++ b/source/manual/how-tos/ipsec-s2s.rst
@@ -485,7 +485,7 @@ Phase 1 won't come up
 That is a difficult one. First check you firewall rules to see if you allow the
 right ports and protocols (ESP, UDP 500 & UDP 4500) for the WAN interface.
 
-Check your ipsec log to see if that reviels a possible cause.
+Check your ipsec log to see if that reveals a possible cause.
 
 Common issues are unequal settings. Both ends must use the
 same PSK and encryption standard.

--- a/source/manual/how-tos/ipv6_fb.rst
+++ b/source/manual/how-tos/ipv6_fb.rst
@@ -150,6 +150,6 @@ connecting via SSH to OPNsense on the CLI.
 
 In the directory `/tmp/` you will find several IPv6 related intermediate files. The most helpful here was `/tmp/<interfacename>_prefixv6`.
 In this file you will find the prefix delegated to you by your upstream router. If you are behind an FB and this file does not exist chances
-are you forgot to seth the **Request only an IPv6 prefix** setting on the WAN interface.
+are you forgot to set the **Request only an IPv6 prefix** setting on the WAN interface.
 
 Another helpful command is `radvdump`. This tool dumps the output of the router advertisements in a nicely formatted way.

--- a/source/manual/how-tos/nginx.rst
+++ b/source/manual/how-tos/nginx.rst
@@ -29,7 +29,7 @@ Give it a useful name and choose the previously created server.
 
 .. image:: images/nginx_edit_location_dialog2.png
 
-Locations are are used to map URLs to upstreams, directories, settings and so on.
+Locations are used to map URLs to upstreams, directories, settings and so on.
 In our case we want to proxy the request to the previously created upstream.
 If we want to match everything, we use "/" without a special matcher.
 Now save the location.

--- a/source/manual/how-tos/nginx_basic_auth.rst
+++ b/source/manual/how-tos/nginx_basic_auth.rst
@@ -82,6 +82,6 @@ Advanced Authentication
 
 The entry advanced authentication is used to call an external authentication
 provider. In the case of OPNsense, this is currently a special script,
-which authenticates agains the local database. If you want to use it,
+which authenticates against the local database. If you want to use it,
 do not enter a realm nor select a user list.
 Please note that this feature may change in the future.

--- a/source/manual/how-tos/nginx_header_hardening.rst
+++ b/source/manual/how-tos/nginx_header_hardening.rst
@@ -94,7 +94,7 @@ opening tools also have a tab for networking.
 The network tab works like the main view of the proxy.
 You can see which headers are sent and which ones are received.
 The advantage here is that you get some errors on the console tab (for example
-if the CSP has an error). The disadvantage of the console is, that is is not so
+if the CSP has an error). The disadvantage of the console is, that it is not so
 easy to intercept and modify data.
 
 

--- a/source/manual/how-tos/nginx_tls_fingerprints.rst
+++ b/source/manual/how-tos/nginx_tls_fingerprints.rst
@@ -48,7 +48,7 @@ One contains ciphers, hashes etc., browsers should not support anymore (for
 example NULL, MD5, ...) so this is probably intercepted (it actually is OWASP 
 ZAP_ 2.7.0) in this screenshot, which is intercepting a connection from
 Firefox 63.
-In this case there is onle one big segment left, which is very likely the real
+In this case there is only one big segment left, which is very likely the real
 browser fingerprint (or another proxy).
 
 In the following example, take a look at the pie chart

--- a/source/manual/how-tos/orange_fr_fttp.rst
+++ b/source/manual/how-tos/orange_fr_fttp.rst
@@ -48,7 +48,7 @@ select options DHCP and DHCPv6 in general configuration
 * dhcp-class-identifier "sagem"
 * user-class "+FSVDSL_livebox.Internet.softathome.Livebox6"
 * option-90 00:00:00:00:00:00:00:00:00:00:00:66:74:69:2f:65:77:74:FF:AB:XX:XX
-  (hex conversion of the the userid supplied by Orange which looks like fti/xxxxxxx)
+  (hex conversion of the userid supplied by Orange which looks like fti/xxxxxxx)
 * dhcp-client-identifier 01:XX:XX:XX:XX:XX:XX
   (you MUST use the same MAC address for the XX:XX as the one use for the DUID above)
 
@@ -101,7 +101,7 @@ then add the following options in the 'Send Options' field
 * raw-option 15 00:2b:46:53:56:44:53:4c:5f:6c:69:76:65:62:6f:78:2e:49:6e:74:65:72:6e:65:74:2e:73:6f:66:74:61:74:68:6f:6d:65:2e:4c:69:76:65:62:6f:78:36
 * raw-option 16 00:00:04:0e:00:05:73:61:67:65:6d
 * raw-option 11 00:00:00:00:00:00:00:00:00:00:00:66:74:69:2f:65:77:74:FF:AB:XX:XX
-  (hex conversion of the the userid supplied by Orange which looks like fti/xxxxxxx)
+  (hex conversion of the userid supplied by Orange which looks like fti/xxxxxxx)
 
 .. Note::
     Use the exact same chain for IPv6 raw-option 11 and IPv4 option-90

--- a/source/manual/how-tos/proxywebfilter.rst
+++ b/source/manual/how-tos/proxywebfilter.rst
@@ -4,7 +4,7 @@ Setup Web Filtering
 Category based web filtering in OPNsense is done by utilizing the built-in proxy
 and one of the freely available or commercial blacklists.
 
-For this this How-to we will utilize the `UT1 "web categorization list" <https://dsi.ut-capitole.fr/blacklists/index_en.php>`__ from the
+For this How-to we will utilize the `UT1 "web categorization list" <https://dsi.ut-capitole.fr/blacklists/index_en.php>`__ from the
 Université Toulouse managed by Fabrice Prigent. This list is supplied for free
 under the `Creative Commons license <http://creativecommons.org/licenses/by-sa/4.0/>`__.
 

--- a/source/manual/how-tos/sslvpn_client.rst
+++ b/source/manual/how-tos/sslvpn_client.rst
@@ -103,7 +103,7 @@ and click **Add** in the top right corner of the form.
 
 .. TIP::
 
-  You can also use the quick-search to jump right into the the Access Server
+  You can also use the quick-search to jump right into the Access Server
   configuration. Try it by typing *Ac...* and see for yourself:
 
   .. image:: images/qs-access_server.png

--- a/source/manual/how-tos/stunnel.rst
+++ b/source/manual/how-tos/stunnel.rst
@@ -32,7 +32,7 @@ authentication, which is more secure but comes with more (connect) overhead (htt
     }
 
 The above diagram shows the basic functionality as provided by this plugin, the client part (not delivered by this plugin) connects to
-to the server at a predefined port and starts forwarding local received packets to the other end of the tunnel.
+the server at a predefined port and starts forwarding local received packets to the other end of the tunnel.
 
 Securing http proxy traffic is one of the more common use-cases of stunnel.
 

--- a/source/manual/how-tos/tor.rst
+++ b/source/manual/how-tos/tor.rst
@@ -40,12 +40,12 @@ Tor Service Settings
     This Port requires a password, which will not be disclosed to the GUI but
     can be queried via the API. This setting is available for you to handle
     Port conflicts, so you can change this port.
-:Create a logfile, Send log messges to syslog:
+:Create a logfile, Send log messages to syslog:
     Enable this checkbox if you want some logging. Please note that a detailed
     log may lead to privacy issues.
 :Logfile, Syslog level:
     If the corresponding checkbox is enabled, this will be the minimum severity
-    for sending or writing log messges.
+    for sending or writing log messages.
 :Fascist Mode:
     If internet access is filtered, you can try this option.
     Please note that this is not compatible with other features like "Hidden Services".
@@ -107,7 +107,7 @@ fill out the form:
 
 :Enable:
     The entry will be added to the configuration file.
-    If this checkbox is unckecked, the entry is ignored.
+    If this checkbox is unchecked, the entry is ignored.
 :Protocol:
     Select the protocol in use for this ACL.
     You can choose between IPv4 and IPv6.

--- a/source/manual/how-tos/user-local.rst
+++ b/source/manual/how-tos/user-local.rst
@@ -56,7 +56,7 @@ the bottom right corner of the form.
 
 
 
-Creating and maintainging API keys
+Creating and maintaining API keys
 ..........................................
 
 .. raw:: html

--- a/source/manual/how-tos/wireguard-s2s.rst
+++ b/source/manual/how-tos/wireguard-s2s.rst
@@ -105,7 +105,7 @@ Enable the *advanced mode* toggle.
     ====================== ====================================================================================================
      **Enabled**            *Checked*
      **Name**               *wgopn-site-a*
-     **Public Key**         *Insert the public key of the instance instance from wgopn-site-a*
+     **Public Key**         *Insert the public key of the instance from wgopn-site-a*
      **Shared Secret**      *Leave empty*
      **Allowed IPs**        *10.2.2.1/32 172.16.0.0/24*
      **Endpoint Address**   *203.0.113.1*

--- a/source/manual/ipv6.rst
+++ b/source/manual/ipv6.rst
@@ -57,7 +57,7 @@ Most concepts explained in this paragraph are part of the `Neighbor Discovery Pr
 Finding your neighbors [NS,NA]
 -------------------------------
 
-For a machine to know it's neighbors, it will use the neighbor discovery protocol (NDP), a bit similar to ARP on IPv4 networks,
+For a machine to know its neighbors, it will use the neighbor discovery protocol (NDP), a bit similar to ARP on IPv4 networks,
 but using Neighbor Solicitation (:code:`ICMPv6 type 135`) and Neighbor Advertisement :code:`ICMPv6 type 136`) messages.
 
 In order to verify if a neighbor is known, you can use the NDP table in :menuselection:`Interfaces --> Diagnostics --> NDP Table`.

--- a/source/manual/proxy.rst
+++ b/source/manual/proxy.rst
@@ -135,7 +135,7 @@ There are some rules to take into account when creating custom themed error page
   Not only is this faster to handle than separate image files it also prevents rendering issues in case images can't be accessed.
 * only existing error pages will be processed, if filenames won't match, the files won't be written to disk. you can use the download button
   to inspect what's being deployed (it will return a combined set of custom and standard files)
-* it's best not to include files that are not altered, this saves room in the configurartion and prevents defauls from being overwritten.
+* it's best not to include files that are not altered, this saves room in the configurartion and prevents defaults from being overwritten.
 
 .. Tip::
 


### PR DESCRIPTION
s/agains/against/
s/are are/are/
s/defauls/defaults/
s/discarted/discarded/
s/growed/have grown/
s/have have/have/
s/instance instance/instance/
s/is is/it is/
s/it's/its/
s/maintainging/maintaining/
s/messges/messages/
s/onle/only/
s/reviels/reveals/
s/temporarly/temporarily/
s/the the/the/
s/this this/this/
s/to seth/to set/
s/to to/to/
s/traffic traffic/traffic/
s/unckecked/unchecked/