### PR TITLE
docs: Add Documentation for HostingerDNS Provider

### DIFF
--- a/source/manual/dynamic_dns.rst
+++ b/source/manual/dynamic_dns.rst
@@ -126,3 +126,21 @@ Username                Key ID
 Password                Secret
 ======================= =======================================================================================================================================================================
 
+Hostinger DNS
+```````````````````````````
+
+Hostinger is a Lithuania hosting provider who offers an API for DNS manipulation:
+
+*     Wiki: https://www.hostinger.com/support/10840865-what-is-hostinger-api/
+*     Technical documentation: https://developers.hostinger.com/#tag/dns-zone/PUT/api/dns/v1/zones/%7Bdomain%7D
+
+
+======================= =======================================================================================================================================================================
+Option                  Value
+======================= =======================================================================================================================================================================
+Username                Leave empty
+Password                Your Hostinger API token
+Zone                    The domain name to update, for example: *example.com*
+Hostname                The record name, for example: *subdomain*
+TTL                     The time to live for the record, in seconds, for example: *300* (optinal default: 300 seconds)      
+======================= =======================================================================================================================================================================


### PR DESCRIPTION
### Overview

Adds documentation for the newly hostinger DDNS provider in the ddclient plugin [https://github.com/opnsense/plugins/pull/5161](url)

### Description

With the recent addition of a new hostinger provider to the ddclient plugin, users need guidance on how to properly set up and configure the integration. This update ensures that the manual reflects the latest changes and supports users in leveraging the new provider effectively.

### Changes Made:

Added a new section dedicated to the Hostinger provider.