### PR TITLE
docs: add BFD strict mode documentation for BGP neighbors

### DIFF
--- a/source/manual/dynamic_routing.rst
+++ b/source/manual/dynamic_routing.rst
@@ -464,6 +464,7 @@ BGP (Border Gateway Protocol)
        **Route Reflector Client**          Marks the neighbor as a client for a route reflector; used to reduce the number of full BGP mesh connections.
        **Soft reconfiguration inbound**    Allows policy changes without resetting the session by storing inbound updates.
        **BFD**                             Enable Bidirectional Forwarding Detection (BFD) for rapid link failure detection with the neighbor.
+       **BFD Strict Mode**                 Strict mode requires the BFD session to be established before allowing BGP to connect. If BFD goes down, BGP immediately closes the session. This prevents BGP sessions from remaining up when the underlying link is down. Requires BFD to be enabled.
        **Keepalive**                       Sets the interval (default 60 seconds) between keepalive messages to check the neighbor's availability.
        **Hold Down Time**                  Time (default 180 seconds) before declaring a neighbor down if no keepalive messages are received.
        **Connect Timer**                   Interval to attempt reconnecting with a neighbor after a disconnect.


### PR DESCRIPTION
## Summary

Documented the new BGP neighbor-level **BFD Strict Mode** option in FRR dynamic routing docs.

### What changed

- Updated `source/manual/dynamic_routing.rst` in the **Routing → BGP → Neighbors** options table.
- Added `BFD Strict Mode` with:
  - behavior: requires BFD session establishment before allowing BGP to connect; BGP immediately closes the session if BFD goes down
  - requirement: BFD must be enabled
  - intent: prevents BGP sessions from remaining up when the underlying link is down, avoiding routing blackholes

## Related

- Plugin implementation: [opnsense/plugins#5315](https://github.com/opnsense/plugins/pull/5315)