### PR TITLE
SSH documentation: remove deprecated Login Group

### DIFF
--- a/source/manual/settingsmenu.rst
+++ b/source/manual/settingsmenu.rst
@@ -119,10 +119,6 @@ Under the "Secure Shell" heading, the following options are available:
 **Option**                                     **Description**
 ============================================== ========================================================================
 Secure Shell Server                            Enable a secure shell service
-Login Group                                    Select the allowed groups for remote login. The "wheel" group is
-                                               always set for recovery purposes and an additional local group can be
-                                               selected at will. Do not yield remote access to non-administrators
-                                               as every user can access system files using SSH or SFTP.
 Permit Root Login                              Root login is generally discouraged. It is advised to log in via
                                                another user and switch to root afterwards.
 Permit password login                          When disabled, authorized keys need to be configured for each User


### PR DESCRIPTION
The Login Group configuration was removed in
https://github.com/opnsense/core/commit/a0581ae0f62b1d3886e8dd5c6fb3c81e3afd8908 (released with versions >=24.1.b) and
https://github.com/opnsense/core/commit/160c393709415cc018a80ee0f0e1af093762f109 (released with versions >=25.7.b), so no longer refer to it in the documentation.