### PR TITLE
fix: correct HTTP method for interfaces overview reload_interface

### DIFF
--- a/source/development/api/core/interfaces.rst
+++ b/source/development/api/core/interfaces.rst
@@ -100,7 +100,7 @@ Interfaces
     "``GET``","interfaces","overview","export",""
     "``GET``","interfaces","overview","get_interface","$if=null"
     "``GET``","interfaces","overview","interfaces_info","$details=false"
-    "``GET``","interfaces","overview","reload_interface","$identifier=null"
+    "``POST``","interfaces","overview","reload_interface","$identifier=null"
 
 .. csv-table:: Resources (SettingsController.php)
    :header: "Method", "Module", "Controller", "Command", "Parameters"


### PR DESCRIPTION
The `reload_interface` command in the OverviewController API table was listed as `GET`, but the actual endpoint requires `POST`. Calling it with GET returns `"failure"`; POST returns `"OK"`.

One-line fix in `source/development/api/core/interfaces.rst`.

Closes #875